### PR TITLE
Refactor: Redesign StatsPage and add UserInsightPanel

### DIFF
--- a/frontend/components/Stats/MonthlyLeaderboard.tsx
+++ b/frontend/components/Stats/MonthlyLeaderboard.tsx
@@ -1,16 +1,25 @@
 import React from "react";
 import { Card, ScrollArea, Table, Title, Anchor } from "@mantine/core";
 import { Person } from "../../types";
+import classes from "../../styles/StatsPage.module.css"; // Import CSS module
 
 interface LeaderboardProps {
   users: Person[];
 }
 
 export function MonthlyLeaderboard({ users }: LeaderboardProps) {
+  // TODO: Update to use actual monthly drink data when available
   const sorted = [...users].sort((a, b) => b.total_drinks - a.total_drinks);
 
   return (
-    <Card shadow="sm" p="md" radius="md" withBorder style={{ flex: 1 }}>
+    <Card
+      shadow="sm"
+      p="md"
+      radius="md"
+      withBorder
+      style={{ flex: 1 }}
+      className={classes.leaderboardCard}
+    >
       <Title order={4} mb="sm">
         This Month
       </Title>
@@ -31,7 +40,8 @@ export function MonthlyLeaderboard({ users }: LeaderboardProps) {
                   <Anchor component="button">{u.name}</Anchor>
                 </td>
                 <td style={{ textAlign: "right" }}>
-                  {u.total_drinks.toLocaleString()}
+                  {u.total_drinks.toLocaleString()}{" "}
+                  {/* TODO: Display actual monthly drink count */}
                 </td>
               </tr>
             ))}

--- a/frontend/components/Stats/OverallStats.tsx
+++ b/frontend/components/Stats/OverallStats.tsx
@@ -3,8 +3,6 @@ import { Card, Grid, Group, Text, ThemeIcon, Title } from "@mantine/core";
 import { IconArrowUpRight, IconArrowDownRight } from "@tabler/icons-react";
 import api from "../../api/api";
 
-interface OverallStatsProps {}
-
 export function OverallStats() {
   const [thisMonth, setThisMonth] = useState(0);
   const [lastMonth, setLastMonth] = useState(0);
@@ -38,9 +36,9 @@ export function OverallStats() {
   const yearChange = calcChange(thisYear, lastYear);
 
   return (
-    <Grid gutter="md" mb="lg">
+    <Grid gutter="md">
       <Grid.Col span={{ base: 12, sm: 6, md: 3 }}>
-        <Card withBorder shadow="sm" radius="md" p="md">
+        <Card radius="md">
           <Text size="xs" fw={700} c="dimmed" mb={5}>
             DRINKS THIS MONTH
           </Text>
@@ -62,7 +60,7 @@ export function OverallStats() {
       </Grid.Col>
 
       <Grid.Col span={{ base: 12, sm: 6, md: 3 }}>
-        <Card withBorder shadow="sm" radius="md" p="md">
+        <Card radius="md">
           <Text size="xs" fw={700} c="dimmed" mb={5}>
             DRINKS THIS YEAR
           </Text>

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useEffect } from "react";
+import {
+  Select,
+  Text,
+  Title,
+  SimpleGrid,
+  Card,
+  Loader,
+} from "@mantine/core";
+import { Person } from "../../types";
+import api from "../../api/api";
+import classes from "../../styles/StatsPage.module.css";
+
+// Define a more specific type for user stats later
+interface UserStatsData {
+  drinks_last_30_days: number;
+  favorite_drink: string;
+  // Add more fields as needed
+}
+
+// Define a more specific type for user stats later
+interface UserStatsData {
+  drinks_last_30_days: number;
+  favorite_drink: string;
+  // Add more fields as needed
+}
+
+export function UserInsightPanel() {
+  const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [userData, setUserData] = useState<UserStatsData | null>(null);
+  const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [loadingUsers, setLoadingUsers] = useState<boolean>(true);
+
+  // Fetch all users for the dropdown
+  useEffect(() => {
+    setLoadingUsers(true);
+    api
+      .get<Person[]>("/users")
+      .then((response) => {
+        const transformedUsers = response.data.map((user) => ({
+          value: user.id.toString(),
+          label: user.name,
+        }));
+        setUsers(transformedUsers);
+      })
+      .catch((_error) => {
+        // Optionally set an error state here
+        // console.error("Error fetching users:", error); 
+      })
+      .finally(() => {
+        setLoadingUsers(false);
+      });
+  }, []);
+
+  // Fetch (mock) stats for the selected user
+  useEffect(() => {
+    if (selectedUserId) {
+      setLoading(true);
+      setUserData(null); // Clear previous data
+
+      // Find user name for display
+      const selectedUser = users.find((user) => user.value === selectedUserId);
+      setSelectedUserName(selectedUser ? selectedUser.label : null);
+
+      // Simulate API call
+      // Replace with actual API call: api.get(`/users/${selectedUserId}/stats`)
+      setTimeout(() => {
+        const mockStats: UserStatsData = {
+          drinks_last_30_days: Math.floor(Math.random() * 100) + 1,
+          favorite_drink: ["Beer", "Wine", "Cocktail", "Coffee", "Water"][
+            Math.floor(Math.random() * 5)
+          ],
+        };
+        setUserData(mockStats);
+        setLoading(false);
+      }, 750); // Simulate network delay
+    } else {
+      setUserData(null);
+      setSelectedUserName(null);
+    }
+  }, [selectedUserId, users]); // Add users to dependency array in case it's initially empty
+
+  return (
+    <div className={classes.userInsightPanel}>
+      <Title order={3} mb="md">
+        User Insights
+      </Title>
+      <Select
+        label="Select User"
+        placeholder="Search or pick a user"
+        data={users}
+        value={selectedUserId}
+        onChange={setSelectedUserId}
+        searchable
+        clearable
+        disabled={loadingUsers}
+        mb="lg"
+        nothingFoundMessage={
+          loadingUsers ? "Loading users..." : "No users found"
+        }
+      />
+
+      {loading && <Loader />}
+
+      {!loading && !selectedUserId && (
+        <Text c="dimmed">Select a user to see their insights.</Text>
+      )}
+
+      {!loading && selectedUserId && userData && selectedUserName && (
+        <>
+          <Title order={4} mb="sm">
+            Stats for {selectedUserName}
+          </Title>
+          <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
+            <Card
+              shadow="sm"
+              p="md"
+              radius="md"
+              className={classes.userStatsCard}
+            >
+              <Text size="xs" c="dimmed" fw={700}>
+                DRINKS (LAST 30 DAYS)
+              </Text>
+              <Text size="xl" fw={500}>
+                {userData.drinks_last_30_days}
+              </Text>
+            </Card>
+            <Card
+              shadow="sm"
+              p="md"
+              radius="md"
+              className={classes.userStatsCard}
+            >
+              <Text size="xs" c="dimmed" fw={700}>
+                FAVORITE DRINK (MOCK)
+              </Text>
+              <Text size="xl" fw={500}>
+                {userData.favorite_drink}
+              </Text>
+            </Card>
+            {/* Add more stat cards here */}
+          </SimpleGrid>
+        </>
+      )}
+      {!loading && selectedUserId && !userData && !selectedUserName && (
+        // This case might happen briefly if user name isn't found before mock data is set
+        <Text c="dimmed">Loading user data...</Text>
+      )}
+    </div>
+  );
+}
+
+export default UserInsightPanel;

--- a/frontend/components/Stats/YearlyLeaderboard.tsx
+++ b/frontend/components/Stats/YearlyLeaderboard.tsx
@@ -1,17 +1,25 @@
 import React from "react";
 import { Card, ScrollArea, Table, Title } from "@mantine/core";
 import { Person } from "../../types";
+import classes from "../../styles/StatsPage.module.css"; // Import CSS module
 
 interface LeaderboardProps {
   users: Person[];
 }
 
 export function YearlyLeaderboard({ users }: LeaderboardProps) {
-  // sort by total_drinks desc, replace with year-specific count
+  // TODO: Update to use actual yearly drink data when available
   const sorted = [...users].sort((a, b) => b.total_drinks - a.total_drinks);
 
   return (
-    <Card shadow="sm" p="md" radius="md" withBorder style={{ flex: 1 }}>
+    <Card
+      shadow="sm"
+      p="md"
+      radius="md"
+      withBorder
+      style={{ flex: 1 }}
+      className={classes.leaderboardCard}
+    >
       <Title order={4} mb="sm">
         This Year
       </Title>
@@ -29,7 +37,10 @@ export function YearlyLeaderboard({ users }: LeaderboardProps) {
               <tr key={u.id}>
                 <td>{i + 1}</td>
                 <td>{u.name}</td>
-                <td>{u.total_drinks}</td>
+                <td>
+                  {u.total_drinks.toLocaleString()}{" "}
+                  {/* TODO: Display actual yearly drink count */}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Container, Divider, Flex } from "@mantine/core";
+import { Container, Grid, Paper } from "@mantine/core"; // Removed Text, Flex, added Grid, Paper
 import api from "../api/api"; // ✅ correct path from 'pages' dir
 import { Person } from "../types";
 import { OverallStats } from "../components/Stats/OverallStats";
 import { MonthlyLeaderboard } from "../components/Stats/MonthlyLeaderboard";
 import { YearlyLeaderboard } from "../components/Stats/YearlyLeaderboard";
+import { UserInsightPanel } from "../components/Stats/UserInsightPanel"; // New import
+import classes from "../styles/StatsPage.module.css"; // Import CSS module
 
 function StatsPage() {
   const [users, setUsers] = useState<Person[]>([]);
@@ -14,13 +16,40 @@ function StatsPage() {
   }, []);
 
   return (
-    <Container py="md">
-      <OverallStats />
-      <Flex gap="md" align="stretch">
-        <MonthlyLeaderboard users={users} />
-        <Divider orientation="vertical" />
-        <YearlyLeaderboard users={users} />
-      </Flex>
+    <Container py="md" className={classes.statsContainer}>
+      {/* Overall Stats - wrapped in Paper */}
+      <Paper withBorder shadow="sm" p="md" mb="lg">
+        <OverallStats />
+      </Paper>
+
+      {/* Leaderboards Section */}
+      <Paper
+        withBorder
+        shadow="sm"
+        p="md"
+        mb="lg"
+        className={classes.leaderboardSection}
+      >
+        <Grid>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <MonthlyLeaderboard users={users} />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 6 }}>
+            <YearlyLeaderboard users={users} />
+          </Grid.Col>
+        </Grid>
+      </Paper>
+
+      {/* User Insight Panel Section */}
+      <Paper
+        withBorder
+        shadow="sm"
+        p="md"
+        mt="lg"
+        className={classes.userInsightSection}
+      >
+        <UserInsightPanel />
+      </Paper>
     </Container>
   );
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,5 +1,6 @@
 // pages/_app.tsx
 import "@mantine/core/styles.css";
+import "../styles/global.css";
 import type { AppProps } from "next/app";
 import { MantineProvider, createTheme } from "@mantine/core";
 import WebLayout from "../components/WebLayout";

--- a/frontend/styles/StatsPage.module.css
+++ b/frontend/styles/StatsPage.module.css
@@ -1,0 +1,33 @@
+.statsContainer {
+  /* border: 1px solid blue; */
+  /* Add any overall container specific styles if needed */
+}
+
+.leaderboardSection {
+  /* border: 1px solid green; */
+  /* background-color: #f9f9f9; */ /* Example light background */
+}
+
+.userInsightSection {
+  /* border: 1px solid orange; */
+  /* background-color: #fefefe; */ /* Example light background */
+}
+
+.leaderboardCard {
+  /* Add any specific styles here, e.g., */
+  /* background-color: #f8f9fa; */
+  /* border-left: 3px solid var(--mantine-color-blue-6); */
+  height: 100%; /* Ensure it fills the Grid.Col height */
+}
+
+.userInsightPanel {
+  /* padding: var(--mantine-spacing-md); */
+  /* Add specific styles if needed */
+}
+
+.userStatsCard {
+  /* background-color: var(--mantine-color-gray-0); */
+  /* border-radius: var(--mantine-radius-md); */
+  /* padding: var(--mantine-spacing-sm); */
+  /* Ensure cards take full height or have min-height if desired */
+}

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #f1f3f5; /* Mantine-like light grey */
+  color: #212529; /* Mantine-like dark text */
+}
+
+.container {
+  max-width: 1200px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Greycliff CF', sans-serif; /* Common Mantine heading font */
+  font-weight: 600;
+  color: #1c1c1c; /* Darker heading color */
+}
+
+/* Layout Utilities */
+.flex-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.flex-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.justify-between {
+  justify-content: space-between;
+}
+
+.gap-xs {
+  gap: 0.5rem; /* Mantine xs spacing */
+}
+.gap-sm {
+  gap: 0.75rem; /* Mantine sm spacing */
+}
+.gap-md {
+  gap: 1rem; /* Mantine md spacing */
+}
+.gap-lg {
+  gap: 1.5rem; /* Mantine lg spacing */
+}
+.gap-xl {
+  gap: 2rem; /* Mantine xl spacing */
+}


### PR DESCRIPTION
This commit introduces a comprehensive redesign of the statistics page (`StatsPage.tsx`) to enhance visual insight and user interactivity.

Key changes include:
- Restructured `StatsPage.tsx` layout using Mantine Grid and Paper components for better organization of overall stats, leaderboards, and a new user insight section.
- Introduced modular styling with `StatsPage.module.css` for page-specific styles and `global.css` for root-level styles (imported in `_app.tsx`).
- Created `UserInsightPanel.tsx`, a new component allowing you to select a specific user from a dropdown and view their (currently mocked) statistics.
- Refactored `OverallStats.tsx`, `MonthlyLeaderboard.tsx`, and `YearlyLeaderboard.tsx` to align with the new design and styling approach.
    - Leaderboards now use a shared `.leaderboardCard` style.
    - Added TODO comments in leaderboards to indicate where actual monthly/yearly data integration is needed, as they currently use placeholder `total_drinks` data.
- Ensured responsiveness with Mantine components.
- Fixed Prettier formatting issues and ESLint warnings (unused imports, props) in the modified files.

The new UserInsightPanel currently uses mocked data for user-specific stats, and the leaderboards require backend updates for accurate monthly/yearly data. These aspects are noted for future work.