### PR TITLE
Add automated backup cron installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,32 @@ To access the admin panel, enter the password defined in your `.env.local`:
 
 ```env
 NEXT_PUBLIC_ADMIN_PASSWORD=your_secure_password
+```
+
+<h2>🗄 Database Backup</h2>
+
+A helper script <code>scripts/backup_db.sh</code> is available to dump the PostgreSQL
+ database and upload the archive to Google Drive or OneDrive using
+<a href="https://rclone.org">rclone</a>. The script keeps only the two most recent
+backups on the remote storage.
+
+Usage example:
+
+```bash
+# Configure rclone with a remote named "gdrive" or "onedrive"
+./scripts/backup_db.sh gdrive DrinkTrackerBackups
+```
+
+To run the backup every day at 2 AM via cron:
+
+```cron
+0 2 * * * /path/to/DrinkTracker/scripts/backup_db.sh gdrive DrinkTrackerBackups
+```
+
+You can automate the setup using `scripts/install_backup_cron.sh`, which
+creates a daily cron entry. The following command installs a job that runs at
+2 AM every day:
+
+```bash
+./scripts/install_backup_cron.sh gdrive DrinkTrackerBackups 2
+```

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./backup_db.sh [remote_name] [remote_path]
+# remote_name: rclone remote name (e.g., gdrive or onedrive)
+# remote_path: directory path on the remote (default: DrinkTrackerBackups)
+
+REMOTE_NAME="${1:-gdrive}"
+REMOTE_PATH="${2:-DrinkTrackerBackups}"
+
+DB_NAME="${POSTGRES_DB:-drinktracker}"
+DB_USER="${POSTGRES_USER:-postgres}"
+DB_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+DB_HOST="${POSTGRES_HOST:-localhost}"
+DB_PORT="${POSTGRES_PORT:-5432}"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="db_backup_${TIMESTAMP}.sql.gz"
+
+export PGPASSWORD="$DB_PASSWORD"
+pg_dump -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+# Upload to remote using rclone
+rclone copy "$BACKUP_FILE" "$REMOTE_NAME:$REMOTE_PATH/"
+rm "$BACKUP_FILE"
+
+# Keep only the two most recent backups on the remote
+BACKUPS=$(rclone lsf "$REMOTE_NAME:$REMOTE_PATH" --format=p | sort -r)
+COUNT=0
+for file in $BACKUPS; do
+    COUNT=$((COUNT+1))
+    if [ $COUNT -gt 2 ]; then
+        rclone deletefile "$REMOTE_NAME:$REMOTE_PATH/$file"
+    fi
+done

--- a/scripts/install_backup_cron.sh
+++ b/scripts/install_backup_cron.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./install_backup_cron.sh [remote_name] [remote_path] [hour]
+# Sets up a daily cron job to run backup_db.sh automatically.
+
+REMOTE_NAME="${1:-gdrive}"
+REMOTE_PATH="${2:-DrinkTrackerBackups}"
+HOUR="${3:-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CRON_ENTRY="0 ${HOUR} * * * ${SCRIPT_DIR}/backup_db.sh ${REMOTE_NAME} ${REMOTE_PATH} >/dev/null 2>&1"
+
+# Remove any existing backup_db.sh entries then install new one
+(crontab -l 2>/dev/null | grep -v backup_db.sh; echo "$CRON_ENTRY") | crontab -
+
+echo "Installed cron job: $CRON_ENTRY"
+


### PR DESCRIPTION
## Summary
- script to install a daily cron job for database backups
- document how to use the installer

## Testing
- `npm test` *(fails: Next.js plugin not detected, ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_b_684286d490ac8326a238a1e6c1086777