### PR TITLE
Add dark mode support with Mantine integration

### DIFF
--- a/frontend/.stylelintrc.cjs
+++ b/frontend/.stylelintrc.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: ['stylelint-config-standard-scss'],
+  rules: {
+    'selector-class-pattern': null,
+    'comment-empty-line-before': null,
+    'font-family-name-quotes': null,
+    'rule-empty-line-before': null,
+    'no-descending-specificity': null,
+  },
+};

--- a/frontend/components/Navbar/NavbarSimple.module.css
+++ b/frontend/components/Navbar/NavbarSimple.module.css
@@ -1,63 +1,69 @@
 .navbar {
-    height: 700px;
-    width: 300px;
-    padding: var(--mantine-spacing-md);
-    display: flex;
-    flex-direction: column;
-    border-right: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-  }
-  
-  .navbarMain {
-    flex: 1;
-  }
-  
-  .header {
-    padding-bottom: var(--mantine-spacing-md);
-    margin-bottom: calc(var(--mantine-spacing-md) * 1.5);
-    border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-  }
-  
-  .footer {
-    padding-top: var(--mantine-spacing-md);
-    margin-top: var(--mantine-spacing-md);
-    border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-  }
-  
-  .link {
-    display: flex;
-    align-items: center;
-    text-decoration: none;
-    font-size: var(--mantine-font-size-sm);
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-1));
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-    border-radius: var(--mantine-radius-sm);
-    font-weight: 500;
-  
-    &:hover {
-      background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
-      color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-    }
+  height: 700px;
+  width: 300px;
+  padding: var(--mantine-spacing-md);
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+}
 
-    &:hover .linkIcon {
-      color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-    }
-  
-    &[data-active] {
-      &,
-      &:hover {
-        background-color: var(--mantine-color-blue-light);
+.navbarMain {
+  flex: 1;
+}
+
+.header {
+  padding-bottom: var(--mantine-spacing-md);
+  margin-bottom: calc(var(--mantine-spacing-md) * 1.5);
+  border-bottom: 1px solid
+    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+.footer {
+  padding-top: var(--mantine-spacing-md);
+  margin-top: var(--mantine-spacing-md);
+  border-top: 1px solid
+    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  font-size: var(--mantine-font-size-sm);
+  color: var(--color-text);
+  padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+  border-radius: var(--mantine-radius-sm);
+  font-weight: 500;
+
+  &:hover {
+    background-color: light-dark(
+      var(--mantine-color-gray-0),
+      var(--mantine-color-dark-6)
+    );
+    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  }
+
+  &:hover .linkIcon {
+    color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  }
+
+  &[data-active] {
+    &,
+    &:hover {
+      background-color: var(--mantine-color-blue-light);
+      color: var(--mantine-color-blue-light-color);
+
+      .linkIcon {
         color: var(--mantine-color-blue-light-color);
-  
-        .linkIcon {
-          color: var(--mantine-color-blue-light-color);
-        }
       }
     }
   }
-  
-  .linkIcon {
-    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
-    margin-right: var(--mantine-spacing-sm);
-    width: 25px;
-    height: 25px;
-  }
+}
+
+.linkIcon {
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
+  margin-right: var(--mantine-spacing-sm);
+  width: 25px;
+  height: 25px;
+}

--- a/frontend/components/Navbar/NavbarSimple.tsx
+++ b/frontend/components/Navbar/NavbarSimple.tsx
@@ -6,8 +6,10 @@ import {
   IconChartDots3,
   IconSettings,
   IconUserPlus, // if you don’t have this, pick another add‑user icon
+  IconSun,
+  IconMoon,
 } from "@tabler/icons-react";
-import { Group, Text } from "@mantine/core";
+import { Group, Text, ActionIcon, useMantineColorScheme } from "@mantine/core";
 import classes from "./NavbarSimple.module.css";
 
 const mainLinks = [
@@ -21,6 +23,7 @@ const footerLinks = [
 
 export default function NavbarSimpleContent() {
   const [active, setActive] = useState("Home");
+  const { colorScheme, toggleColorScheme } = useMantineColorScheme();
 
   return (
     <>
@@ -32,15 +35,15 @@ export default function NavbarSimpleContent() {
 
       {/* main navigation */}
       {mainLinks.map((item) => (
-        <Link key={item.label} href={item.href} passHref legacyBehavior>
-          <a
-            className={classes.link}
-            data-active={item.label === active || undefined}
-            onClick={() => setActive(item.label)}
-          >
-            <item.icon className={classes.linkIcon} stroke={1.5} />
-            <span>{item.label}</span>
-          </a>
+        <Link
+          key={item.label}
+          href={item.href}
+          className={classes.link}
+          data-active={item.label === active || undefined}
+          onClick={() => setActive(item.label)}
+        >
+          <item.icon className={classes.linkIcon} stroke={1.5} />
+          <span>{item.label}</span>
         </Link>
       ))}
 
@@ -50,17 +53,30 @@ export default function NavbarSimpleContent() {
       {/* footer navigation */}
       <div className={classes.footer}>
         {footerLinks.map((item) => (
-          <Link key={item.label} href={item.href} passHref legacyBehavior>
-            <a
-              className={classes.link}
-              data-active={item.label === active || undefined}
-              onClick={() => setActive(item.label)}
-            >
-              <item.icon className={classes.linkIcon} stroke={1.5} />
-              <span>{item.label}</span>
-            </a>
+          <Link
+            key={item.label}
+            href={item.href}
+            className={classes.link}
+            data-active={item.label === active || undefined}
+            onClick={() => setActive(item.label)}
+          >
+            <item.icon className={classes.linkIcon} stroke={1.5} />
+            <span>{item.label}</span>
           </Link>
         ))}
+        <ActionIcon
+          aria-label="Toggle color scheme"
+          onClick={() => toggleColorScheme()}
+          variant="default"
+          size="lg"
+          className={classes.link}
+        >
+          {colorScheme === "dark" ? (
+            <IconSun className={classes.linkIcon} stroke={1.5} />
+          ) : (
+            <IconMoon className={classes.linkIcon} stroke={1.5} />
+          )}
+        </ActionIcon>
       </div>
     </>
   );

--- a/frontend/components/Navbar/__tests__/NavbarThemeToggle.test.tsx
+++ b/frontend/components/Navbar/__tests__/NavbarThemeToggle.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NavbarSimpleContent from "../NavbarSimple";
+import {
+  MantineProvider,
+  useMantineColorScheme,
+  localStorageColorSchemeManager,
+} from "@mantine/core";
+import { theme, colorSchemeStorageKey } from "../../../theme";
+import { useEffect } from "react";
+
+test("toggles theme attribute", async () => {
+  const manager = localStorageColorSchemeManager({
+    key: colorSchemeStorageKey,
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <MantineProvider
+        theme={theme}
+        colorSchemeManager={manager}
+        defaultColorScheme="light"
+        withCssVariables
+      >
+        <Inner>{children}</Inner>
+      </MantineProvider>
+    );
+  };
+
+  const Inner = ({ children }: { children: React.ReactNode }) => {
+    const { colorScheme } = useMantineColorScheme();
+    useEffect(() => {
+      document.documentElement.setAttribute("data-theme", colorScheme);
+    }, [colorScheme]);
+    return <>{children}</>;
+  };
+  render(<NavbarSimpleContent />, { wrapper: Wrapper });
+  const button = screen.getByLabelText(/toggle color scheme/i);
+  expect(document.documentElement).toHaveAttribute("data-theme", "light");
+  await userEvent.click(button);
+  expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+});

--- a/frontend/components/Settings/UserManagement.tsx
+++ b/frontend/components/Settings/UserManagement.tsx
@@ -30,7 +30,9 @@ export function UserManagement({ users, setUsers }: Props) {
   };
 
   const deleteUser = async () => {
-    if (!targetUser) return;
+    if (!targetUser) {
+      return;
+    }
     await api.delete(`/users/${targetUser.id}`);
     setUsers(users.filter((u) => u.id !== targetUser.id));
     setConfirmOpen(false);

--- a/frontend/pages/SettingsPage.tsx
+++ b/frontend/pages/SettingsPage.tsx
@@ -31,7 +31,9 @@ export default function SettingsPage() {
   const [payments, setPayments] = useState<Payment[]>([]);
 
   useEffect(() => {
-    if (!isAuth) return;
+    if (!isAuth) {
+      return;
+    }
     api.get<Person[]>("/users").then((r) => setUsers(r.data));
     api.get<Payment[]>("/payments").then((r) => setPayments(r.data));
   }, [isAuth]);

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,20 +2,38 @@
 import "@mantine/core/styles.css";
 import "../styles/global.css";
 import type { AppProps } from "next/app";
-import { MantineProvider, createTheme } from "@mantine/core";
+import {
+  MantineProvider,
+  useMantineColorScheme,
+  localStorageColorSchemeManager,
+} from "@mantine/core";
+import { useEffect } from "react";
 import WebLayout from "../components/WebLayout";
+import { theme, colorSchemeStorageKey } from "../theme";
 
-// Optional: customize the theme if needed
-const theme = createTheme({
-  // You can add other theme settings here
-});
+const manager = localStorageColorSchemeManager({ key: colorSchemeStorageKey });
+
+function Providers({ children }: { children: React.ReactNode }) {
+  const { colorScheme } = useMantineColorScheme();
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", colorScheme);
+  }, [colorScheme]);
+  return <>{children}</>;
+}
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <MantineProvider theme={theme}>
-      <WebLayout>
-        <Component {...pageProps} />
-      </WebLayout>
+    <MantineProvider
+      theme={theme}
+      colorSchemeManager={manager}
+      defaultColorScheme="light"
+      withCssVariables
+    >
+      <Providers>
+        <WebLayout>
+          <Component {...pageProps} />
+        </WebLayout>
+      </Providers>
     </MantineProvider>
   );
 }

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,11 +1,17 @@
 import { Head, Html, Main, NextScript } from "next/document";
 import { ColorSchemeScript, mantineHtmlProps } from "@mantine/core";
+import { colorSchemeStorageKey } from "../theme";
 
 export default function Document() {
   return (
     <Html lang="en" {...mantineHtmlProps}>
       <Head>
-        <ColorSchemeScript />
+        <ColorSchemeScript localStorageKey={colorSchemeStorageKey} />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => { const t = localStorage.getItem('${colorSchemeStorageKey}') || 'light'; document.documentElement.setAttribute('data-theme', t); })();`,
+          }}
+        />
       </Head>
       <body>
         <Main />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -45,7 +45,9 @@ export default function HomePage() {
 
   const handleDrink = async (userId: number) => {
     const user = users.find((u) => u.id === userId);
-    if (!user) return;
+    if (!user) {
+      return;
+    }
 
     if (user.balance <= 0) {
       // Open top-up modal instead
@@ -88,7 +90,9 @@ export default function HomePage() {
   };
 
   const confirmTopUp = async () => {
-    if (!topUpUser) return;
+    if (!topUpUser) {
+      return;
+    }
     const { data } = await api.post<{ checkoutUrl: string }>(
       "/payments/topup",
       {

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -1,12 +1,24 @@
+:root {
+  --color-bg: #f1f3f5;
+  --color-text: #212529;
+  --color-border: #ced4da;
+}
+
+[data-theme="dark"] {
+  --color-bg: #1a1b1e;
+  --color-text: #c1c2c5;
+  --color-border: #373a40;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f1f3f5; /* Mantine-like light grey */
-  color: #212529; /* Mantine-like dark text */
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .container {
@@ -17,8 +29,13 @@ body {
   padding-right: 1rem;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Greycliff CF', sans-serif; /* Common Mantine heading font */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Greycliff CF", sans-serif; /* Common Mantine heading font */
   font-weight: 600;
   color: #1c1c1c; /* Darker heading color */
 }

--- a/frontend/theme.ts
+++ b/frontend/theme.ts
@@ -1,5 +1,7 @@
 import { createTheme } from "@mantine/core";
 
+export const colorSchemeStorageKey = "dt-color-scheme";
+
 export const theme = createTheme({
   /* Put your mantine theme override here */
 });


### PR DESCRIPTION
## Summary
- define CSS variables for background, text and border colors
- integrate Mantine color scheme manager in `_app`
- add theme attribute update script in `_document`
- use variables in `NavbarSimple.module.css`
- implement toggle in `NavbarSimple.tsx`
- provide theme toggle test and stylelint config

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6842877c3800832680f4e0416c939a9b