### PR TITLE
Fix duplicate interface definition

### DIFF
--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,22 +1,8 @@
 import React, { useState, useEffect } from "react";
-import {
-  Select,
-  Text,
-  Title,
-  SimpleGrid,
-  Card,
-  Loader,
-} from "@mantine/core";
+import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
-
-// Define a more specific type for user stats later
-interface UserStatsData {
-  drinks_last_30_days: number;
-  favorite_drink: string;
-  // Add more fields as needed
-}
 
 // Define a more specific type for user stats later
 interface UserStatsData {
@@ -47,7 +33,7 @@ export function UserInsightPanel() {
       })
       .catch((_error) => {
         // Optionally set an error state here
-        // console.error("Error fetching users:", error); 
+        // console.error("Error fetching users:", error);
       })
       .finally(() => {
         setLoadingUsers(false);


### PR DESCRIPTION
## Summary
- remove an extra `UserStatsData` interface definition
- run Prettier formatting on affected file

## Testing
- `npm test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68428b8138ac83268c02348cc7246456