### PR TITLE
Update patch endpoint for undo

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -36,11 +36,15 @@ def record_drink(db: Session, person_id: int):
     return person
 
 # crud.py
-def update_user_balance(db: Session, user_id: int, new_balance: float):
+def update_user_balance(
+    db: Session, user_id: int, new_balance: float, new_total_drinks: int | None = None
+):
     person = get_person(db, user_id)
     if not person:
         return None
     person.balance = new_balance
+    if new_total_drinks is not None:
+        person.total_drinks = new_total_drinks
     db.commit()
     db.refresh(person)
     return person

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ app = FastAPI()
 
 class UpdateUser(BaseModel):
     balance: float
+    total_drinks: int | None = None
 
 app.add_middleware(
     CORSMiddleware,
@@ -51,7 +52,7 @@ def list_payments(db: Session = Depends(get_db)):
 
 @app.patch("/users/{user_id}")
 def update_user(user_id: int, update: UpdateUser, db: Session = Depends(get_db)):
-    person = crud.update_user_balance(db, user_id, update.balance)
+    person = crud.update_user_balance(db, user_id, update.balance, update.total_drinks)
     if not person:
         raise HTTPException(status_code=404, detail="User not found")
     return person


### PR DESCRIPTION
## Summary
- allow optional `total_drinks` in update payload
- update user patch endpoint to forward optional drink count
- handle drink count update in CRUD helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68428b826c888326a2f1e2d80d865d7b