### PR TITLE
Implement user stats endpoint and tests

### DIFF
--- a/backend/tests/test_user_stats.py
+++ b/backend/tests/test_user_stats.py
@@ -1,0 +1,63 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from datetime import datetime, timedelta
+import sys
+import os
+
+# Ensure backend/app is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide dummy env vars so database module can be imported
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ["TESTING"] = "1"
+
+from app.main import app, get_db
+from app.models import Base, Person, DrinkEvent
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def test_user_stats_last_30_days():
+    db = TestingSessionLocal()
+    # create user and events
+    user = Person(name="Test")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    user_id = user.id
+
+    # within last 30 days
+    event_recent = DrinkEvent(person_id=user.id, timestamp=datetime.utcnow() - timedelta(days=5))
+    # older than 30 days
+    event_old = DrinkEvent(person_id=user.id, timestamp=datetime.utcnow() - timedelta(days=40))
+    db.add_all([event_recent, event_old])
+    db.commit()
+    db.close()
+
+    response = client.get(f"/users/{user_id}/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["drinks_last_30_days"] == 1
+    assert "favorite_drink" in data

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -11,18 +11,9 @@ import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
 
-// Define a more specific type for user stats later
 interface UserStatsData {
   drinks_last_30_days: number;
   favorite_drink: string;
-  // Add more fields as needed
-}
-
-// Define a more specific type for user stats later
-interface UserStatsData {
-  drinks_last_30_days: number;
-  favorite_drink: string;
-  // Add more fields as needed
 }
 
 export function UserInsightPanel() {
@@ -54,7 +45,7 @@ export function UserInsightPanel() {
       });
   }, []);
 
-  // Fetch (mock) stats for the selected user
+  // Fetch stats for the selected user
   useEffect(() => {
     if (selectedUserId) {
       setLoading(true);
@@ -64,18 +55,18 @@ export function UserInsightPanel() {
       const selectedUser = users.find((user) => user.value === selectedUserId);
       setSelectedUserName(selectedUser ? selectedUser.label : null);
 
-      // Simulate API call
-      // Replace with actual API call: api.get(`/users/${selectedUserId}/stats`)
-      setTimeout(() => {
-        const mockStats: UserStatsData = {
-          drinks_last_30_days: Math.floor(Math.random() * 100) + 1,
-          favorite_drink: ["Beer", "Wine", "Cocktail", "Coffee", "Water"][
-            Math.floor(Math.random() * 5)
-          ],
-        };
-        setUserData(mockStats);
-        setLoading(false);
-      }, 750); // Simulate network delay
+      api
+        .get<UserStatsData>(`/users/${selectedUserId}/stats`)
+        .then((response) => {
+          setUserData(response.data);
+        })
+        .catch(() => {
+          // Optionally handle error state
+          setUserData(null);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
     } else {
       setUserData(null);
       setSelectedUserName(null);


### PR DESCRIPTION
## Summary
- add per-user stats API on the backend
- skip DB init in test mode and compute last 30 days
- integrate UserInsightPanel with the real API
- add backend unit tests for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68428be4eff48326b39efb591b7d9068