### PR TITLE
Add monthly/yearly leaderboards

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends, HTTPException
 from sqlalchemy.orm import Session
+from sqlalchemy import func, and_
 from . import models, schemas, crud
 from .database import engine, Base, get_db
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,8 +11,10 @@ Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
+
 class UpdateUser(BaseModel):
     balance: float
+
 
 app.add_middleware(
     CORSMiddleware,
@@ -20,18 +23,22 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
 @app.get("/users", response_model=list[schemas.Person])
 def read_users(db: Session = Depends(get_db)):
     return crud.get_persons(db)
+
 
 @app.post("/users", response_model=schemas.Person)
 def create_user(person: schemas.PersonCreate, db: Session = Depends(get_db)):
     return crud.create_person(db, person)
 
+
 @app.delete("/users/{user_id}")
 def delete_user(user_id: int, db: Session = Depends(get_db)):
     crud.delete_person(db, user_id)
     return {"ok": True}
+
 
 @app.post("/users/{user_id}/drinks", response_model=schemas.Person)
 def add_drink(user_id: int, db: Session = Depends(get_db)):
@@ -40,14 +47,17 @@ def add_drink(user_id: int, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="User not found")
     return person
 
+
 @app.post("/payments/topup")
 def top_up(payment: schemas.PaymentCreate, db: Session = Depends(get_db)):
     url = crud.create_payment(db, payment)
     return {"checkoutUrl": url}
 
+
 @app.get("/payments", response_model=list[schemas.Payment])
 def list_payments(db: Session = Depends(get_db)):
     return db.query(models.Payment).all()
+
 
 @app.patch("/users/{user_id}")
 def update_user(user_id: int, update: UpdateUser, db: Session = Depends(get_db)):
@@ -56,12 +66,14 @@ def update_user(user_id: int, update: UpdateUser, db: Session = Depends(get_db))
         raise HTTPException(status_code=404, detail="User not found")
     return person
 
+
 @app.get("/users/{user_id}", response_model=schemas.Person)
 def get_user(user_id: int, db: Session = Depends(get_db)):
     user = crud.get_person(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
+
 
 def get_date_range_this_month():
     now = datetime.utcnow()
@@ -70,6 +82,7 @@ def get_date_range_this_month():
     end = next_month.replace(day=1)
     return start, end
 
+
 def get_date_range_last_month():
     now = datetime.utcnow()
     start_this_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
@@ -77,34 +90,109 @@ def get_date_range_last_month():
     start = (start_this_month - timedelta(days=1)).replace(day=1)
     return start, end
 
+
 def get_date_range_this_year():
     now = datetime.utcnow()
     start = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
     end = now.replace(month=12, day=31, hour=23, minute=59, second=59)
     return start, end
 
+
 def get_date_range_last_year():
     now = datetime.utcnow()
     start = now.replace(year=now.year - 1, month=1, day=1, hour=0, minute=0, second=0)
-    end = now.replace(year=now.year - 1, month=12, day=31, hour=23, minute=59, second=59)
+    end = now.replace(
+        year=now.year - 1, month=12, day=31, hour=23, minute=59, second=59
+    )
     return start, end
+
 
 @app.get("/stats/drinks_this_month")
 def drinks_this_month(db: Session = Depends(get_db)):
     start, end = get_date_range_this_month()
-    return db.query(models.DrinkEvent).filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp < end).count()
+    return (
+        db.query(models.DrinkEvent)
+        .filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp < end)
+        .count()
+    )
+
 
 @app.get("/stats/drinks_last_month")
 def drinks_last_month(db: Session = Depends(get_db)):
     start, end = get_date_range_last_month()
-    return db.query(models.DrinkEvent).filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp < end).count()
+    return (
+        db.query(models.DrinkEvent)
+        .filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp < end)
+        .count()
+    )
+
 
 @app.get("/stats/drinks_this_year")
 def drinks_this_year(db: Session = Depends(get_db)):
     start, end = get_date_range_this_year()
-    return db.query(models.DrinkEvent).filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp <= end).count()
+    return (
+        db.query(models.DrinkEvent)
+        .filter(
+            models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp <= end
+        )
+        .count()
+    )
+
 
 @app.get("/stats/drinks_last_year")
 def drinks_last_year(db: Session = Depends(get_db)):
     start, end = get_date_range_last_year()
-    return db.query(models.DrinkEvent).filter(models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp <= end).count()
+
+    return (
+        db.query(models.DrinkEvent)
+        .filter(
+            models.DrinkEvent.timestamp >= start, models.DrinkEvent.timestamp <= end
+        )
+        .count()
+    )
+
+
+@app.get("/stats/monthly_leaderboard")
+def monthly_leaderboard(db: Session = Depends(get_db)):
+    start, end = get_date_range_this_month()
+    results = (
+        db.query(
+            models.Person.id,
+            models.Person.name,
+            func.count(models.DrinkEvent.id).label("drinks"),
+        )
+        .outerjoin(
+            models.DrinkEvent,
+            and_(
+                models.DrinkEvent.person_id == models.Person.id,
+                models.DrinkEvent.timestamp >= start,
+                models.DrinkEvent.timestamp < end,
+            ),
+        )
+        .group_by(models.Person.id)
+        .all()
+    )
+    return [{"id": r.id, "name": r.name, "drinks": int(r.drinks)} for r in results]
+
+
+@app.get("/stats/yearly_leaderboard")
+def yearly_leaderboard(db: Session = Depends(get_db)):
+    start, end = get_date_range_this_year()
+    results = (
+        db.query(
+            models.Person.id,
+            models.Person.name,
+            func.count(models.DrinkEvent.id).label("drinks"),
+        )
+        .outerjoin(
+            models.DrinkEvent,
+            and_(
+                models.DrinkEvent.person_id == models.Person.id,
+                models.DrinkEvent.timestamp >= start,
+                models.DrinkEvent.timestamp <= end,
+            ),
+        )
+        .group_by(models.Person.id)
+        .all()
+    )
+    return [{"id": r.id, "name": r.name, "drinks": int(r.drinks)} for r in results]

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -1,0 +1,129 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, and_
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from datetime import timedelta
+import sys
+import types
+from unittest import mock
+
+# Stub mollie client to avoid optional dependency in tests
+mollie = types.ModuleType("mollie")
+api_mod = types.ModuleType("api")
+client_mod = types.ModuleType("client")
+client_mod.Client = object
+api_mod.client = client_mod
+mollie.api = api_mod
+sys.modules.setdefault("mollie", mollie)
+sys.modules.setdefault("mollie.api", api_mod)
+sys.modules.setdefault("mollie.api.client", client_mod)
+
+test_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+with mock.patch("sqlalchemy.create_engine", lambda *a, **k: test_engine):
+    from app.main import (
+        app,
+        get_db,
+        get_date_range_this_month,
+        get_date_range_last_month,
+        get_date_range_this_year,
+        get_date_range_last_year,
+    )
+    from app import models
+    from app.database import Base
+
+
+def create_test_app():
+    TestingSessionLocal = sessionmaker(
+        bind=test_engine, autoflush=False, autocommit=False
+    )
+    Base.metadata.drop_all(bind=test_engine)
+    Base.metadata.create_all(bind=test_engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    return client, TestingSessionLocal
+
+
+def setup_test_data(SessionLocal):
+    with SessionLocal() as db:
+        alice = models.Person(name="Alice")
+        bob = models.Person(name="Bob")
+        charlie = models.Person(name="Charlie")
+        db.add_all([alice, bob, charlie])
+        db.commit()
+        db.refresh(alice)
+        db.refresh(bob)
+        db.refresh(charlie)
+
+        start_month, _ = get_date_range_this_month()
+        start_year, _ = get_date_range_this_year()
+        start_last_month, _ = get_date_range_last_month()
+        start_last_year, _ = get_date_range_last_year()
+
+        events = [
+            models.DrinkEvent(
+                person_id=alice.id, timestamp=start_month + timedelta(days=1)
+            ),
+            models.DrinkEvent(
+                person_id=alice.id, timestamp=start_month + timedelta(days=2)
+            ),
+            models.DrinkEvent(
+                person_id=bob.id, timestamp=start_month + timedelta(days=3)
+            ),
+            models.DrinkEvent(
+                person_id=alice.id, timestamp=start_year + timedelta(days=1)
+            ),
+            models.DrinkEvent(
+                person_id=alice.id, timestamp=start_last_month + timedelta(days=1)
+            ),
+            models.DrinkEvent(
+                person_id=bob.id, timestamp=start_last_year + timedelta(days=1)
+            ),
+        ]
+        db.add_all(events)
+        db.commit()
+
+
+@pytest.fixture
+def client_session():
+    client, SessionLocal = create_test_app()
+    setup_test_data(SessionLocal)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_monthly_leaderboard(client_session):
+    client = client_session
+    resp = client.get("/stats/monthly_leaderboard")
+    assert resp.status_code == 200
+    data = sorted(resp.json(), key=lambda x: x["name"])
+    assert data == [
+        {"id": 1, "name": "Alice", "drinks": 2},
+        {"id": 2, "name": "Bob", "drinks": 1},
+        {"id": 3, "name": "Charlie", "drinks": 0},
+    ]
+
+
+def test_yearly_leaderboard(client_session):
+    client = client_session
+    resp = client.get("/stats/yearly_leaderboard")
+    assert resp.status_code == 200
+    data = sorted(resp.json(), key=lambda x: x["name"])
+    assert data == [
+        {"id": 1, "name": "Alice", "drinks": 4},
+        {"id": 2, "name": "Bob", "drinks": 1},
+        {"id": 3, "name": "Charlie", "drinks": 0},
+    ]

--- a/frontend/components/Stats/MonthlyLeaderboard.tsx
+++ b/frontend/components/Stats/MonthlyLeaderboard.tsx
@@ -1,15 +1,24 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, ScrollArea, Table, Title, Anchor } from "@mantine/core";
-import { Person } from "../../types";
+import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css"; // Import CSS module
 
-interface LeaderboardProps {
-  users: Person[];
+interface LeaderboardEntry {
+  id: number;
+  name: string;
+  drinks: number;
 }
 
-export function MonthlyLeaderboard({ users }: LeaderboardProps) {
-  // TODO: Update to use actual monthly drink data when available
-  const sorted = [...users].sort((a, b) => b.total_drinks - a.total_drinks);
+export function MonthlyLeaderboard() {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+
+  useEffect(() => {
+    api.get<LeaderboardEntry[]>("/stats/monthly_leaderboard").then((r) => {
+      setEntries(r.data);
+    });
+  }, []);
+
+  const sorted = [...entries].sort((a, b) => b.drinks - a.drinks);
 
   return (
     <Card
@@ -40,8 +49,7 @@ export function MonthlyLeaderboard({ users }: LeaderboardProps) {
                   <Anchor component="button">{u.name}</Anchor>
                 </td>
                 <td style={{ textAlign: "right" }}>
-                  {u.total_drinks.toLocaleString()}{" "}
-                  {/* TODO: Display actual monthly drink count */}
+                  {u.drinks.toLocaleString()}
                 </td>
               </tr>
             ))}

--- a/frontend/components/Stats/YearlyLeaderboard.tsx
+++ b/frontend/components/Stats/YearlyLeaderboard.tsx
@@ -1,15 +1,24 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Card, ScrollArea, Table, Title } from "@mantine/core";
-import { Person } from "../../types";
+import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css"; // Import CSS module
 
-interface LeaderboardProps {
-  users: Person[];
+interface LeaderboardEntry {
+  id: number;
+  name: string;
+  drinks: number;
 }
 
-export function YearlyLeaderboard({ users }: LeaderboardProps) {
-  // TODO: Update to use actual yearly drink data when available
-  const sorted = [...users].sort((a, b) => b.total_drinks - a.total_drinks);
+export function YearlyLeaderboard() {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+
+  useEffect(() => {
+    api.get<LeaderboardEntry[]>("/stats/yearly_leaderboard").then((r) => {
+      setEntries(r.data);
+    });
+  }, []);
+
+  const sorted = [...entries].sort((a, b) => b.drinks - a.drinks);
 
   return (
     <Card
@@ -37,10 +46,7 @@ export function YearlyLeaderboard({ users }: LeaderboardProps) {
               <tr key={u.id}>
                 <td>{i + 1}</td>
                 <td>{u.name}</td>
-                <td>
-                  {u.total_drinks.toLocaleString()}{" "}
-                  {/* TODO: Display actual yearly drink count */}
-                </td>
+                <td>{u.drinks.toLocaleString()}</td>
               </tr>
             ))}
           </tbody>

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -1,20 +1,12 @@
-import React, { useState, useEffect } from "react";
-import { Container, Grid, Paper } from "@mantine/core"; // Removed Text, Flex, added Grid, Paper
-import api from "../api/api"; // ✅ correct path from 'pages' dir
-import { Person } from "../types";
+import React from "react";
+import { Container, Grid, Paper } from "@mantine/core";
 import { OverallStats } from "../components/Stats/OverallStats";
 import { MonthlyLeaderboard } from "../components/Stats/MonthlyLeaderboard";
 import { YearlyLeaderboard } from "../components/Stats/YearlyLeaderboard";
-import { UserInsightPanel } from "../components/Stats/UserInsightPanel"; // New import
-import classes from "../styles/StatsPage.module.css"; // Import CSS module
+import { UserInsightPanel } from "../components/Stats/UserInsightPanel";
+import classes from "../styles/StatsPage.module.css";
 
 function StatsPage() {
-  const [users, setUsers] = useState<Person[]>([]);
-
-  useEffect(() => {
-    api.get<Person[]>("/users").then((r) => setUsers(r.data));
-  }, []);
-
   return (
     <Container py="md" className={classes.statsContainer}>
       {/* Overall Stats - wrapped in Paper */}
@@ -32,10 +24,10 @@ function StatsPage() {
       >
         <Grid>
           <Grid.Col span={{ base: 12, md: 6 }}>
-            <MonthlyLeaderboard users={users} />
+            <MonthlyLeaderboard />
           </Grid.Col>
           <Grid.Col span={{ base: 12, md: 6 }}>
-            <YearlyLeaderboard users={users} />
+            <YearlyLeaderboard />
           </Grid.Col>
         </Grid>
       </Paper>


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to compute per-user monthly/yearly drink counts
- update frontend leaderboards to fetch new stats
- simplify StatsPage state handling
- include pytest covering leaderboard logic

## Testing
- `PYTHONPATH=backend pytest -q`
- `npm test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68428bf2fb2c8326b47170aca7f441f5