### PR TITLE
Add multi-user form

### DIFF
--- a/frontend/pages/AddUserPage.tsx
+++ b/frontend/pages/AddUserPage.tsx
@@ -1,41 +1,134 @@
 import React, { useState } from "react";
-import { useRouter } from "next/router";
-import { TextInput, Button, Group, Paper, Title, Stack } from "@mantine/core";
+import {
+  TextInput,
+  Button,
+  Group,
+  Paper,
+  Title,
+  Stack,
+  ActionIcon,
+  Notification,
+} from "@mantine/core";
+import { IconPlus, IconTrash, IconCheck, IconX } from "@tabler/icons-react";
 import api from "../api/api";
 import { AdminGate } from "../components/Admin/AdminGate";
 
+interface UserNotification {
+  id: number;
+  name: string;
+  success: boolean;
+  message?: string;
+}
+
 export default function AddUserPage() {
-  const [name, setName] = useState("");
-  const router = useRouter();
+  const [names, setNames] = useState<string[]>([""]);
+  const [notifications, setNotifications] = useState<UserNotification[]>([]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await api.post("/users", { name });
-    router.push("/");
+    const trimmed = names.map((n) => n.trim()).filter((n) => n);
+    const results: UserNotification[] = [];
+    for (const n of trimmed) {
+      try {
+        await api.post("/users", { name: n });
+        results.push({
+          id: Date.now() + Math.random(),
+          name: n,
+          success: true,
+        });
+      } catch (err: any) {
+        const msg = err?.response?.data?.detail ?? "Failed to add";
+        results.push({
+          id: Date.now() + Math.random(),
+          name: n,
+          success: false,
+          message: msg,
+        });
+      }
+    }
+    setNotifications((prev) => [...prev, ...results]);
+    if (results.every((r) => r.success)) {
+      setNames([""]);
+    }
   };
+
+  const addField = () => setNames((prev) => [...prev, ""]);
+  const removeField = (idx: number) =>
+    setNames((prev) => prev.filter((_, i) => i !== idx));
+  const changeField = (idx: number, value: string) =>
+    setNames((prev) => prev.map((n, i) => (i === idx ? value : n)));
 
   return (
     <AdminGate>
       <Paper shadow="sm" p="lg" maw={400} mx="auto">
         <Title order={3} mb="md">
-          Add New User
+          Add New Users
         </Title>
 
         <form onSubmit={handleSubmit}>
           <Stack>
-            <TextInput
-              label="Name"
-              placeholder="Enter user name"
-              required
-              value={name}
-              onChange={(e) => setName(e.currentTarget.value)}
-            />
+            {names.map((n, idx) => (
+              <Group key={idx} align="flex-end">
+                <TextInput
+                  label="Name"
+                  placeholder="Enter user name"
+                  required
+                  flex={1}
+                  value={n}
+                  onChange={(e) => changeField(idx, e.currentTarget.value)}
+                />
+                {names.length > 1 && (
+                  <ActionIcon
+                    color="red"
+                    variant="subtle"
+                    mt="sm"
+                    onClick={() => removeField(idx)}
+                    aria-label="Remove"
+                  >
+                    <IconTrash size={16} />
+                  </ActionIcon>
+                )}
+              </Group>
+            ))}
+
+            <Button
+              variant="light"
+              leftSection={<IconPlus size={16} />}
+              onClick={addField}
+            >
+              Add Another
+            </Button>
 
             <Group justify="flex-end">
-              <Button type="submit">Create User</Button>
+              <Button type="submit">Create Users</Button>
             </Group>
           </Stack>
         </form>
+
+        <Stack pos="fixed" bottom={16} right={16} gap="sm">
+          {notifications.map((n) => (
+            <Notification
+              key={n.id}
+              withCloseButton
+              onClose={() =>
+                setNotifications((prev) => prev.filter((nn) => nn.id !== n.id))
+              }
+              color={n.success ? "teal" : "red"}
+              icon={n.success ? <IconCheck size={16} /> : <IconX size={16} />}
+              title={n.success ? "User added" : "Error"}
+            >
+              {n.success ? (
+                <>
+                  Added <strong>{n.name}</strong>
+                </>
+              ) : (
+                <>
+                  Failed to add <strong>{n.name}</strong>: {n.message}
+                </>
+              )}
+            </Notification>
+          ))}
+        </Stack>
       </Paper>
     </AdminGate>
   );

--- a/frontend/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/pages/__tests__/AddUserPage.test.tsx
@@ -1,0 +1,41 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent, waitFor } from "../../test-utils";
+import AddUserPage from "../AddUserPage";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  localStorage.clear();
+});
+
+test("adds multiple users", async () => {
+  mock.onPost("/auth/login").reply(200, { access_token: "tok" });
+  mock.onPost("/users").reply(201);
+
+  render(<AddUserPage />);
+
+  await userEvent.type(
+    screen.getByPlaceholderText(/enter admin password/i),
+    "pass",
+  );
+  await userEvent.click(screen.getByRole("button", { name: /login/i }));
+
+  await waitFor(() => expect(localStorage.getItem("admin_token")).toBe("tok"));
+
+  await userEvent.click(screen.getByRole("button", { name: /add another/i }));
+  const inputs = screen.getAllByLabelText(/name/i);
+  await userEvent.type(inputs[0], "Alice");
+  await userEvent.type(inputs[1], "Bob");
+
+  await userEvent.click(screen.getByRole("button", { name: /create users/i }));
+
+  await waitFor(() =>
+    expect(mock.history.post.filter((r) => r.url === "/users").length).toBe(2),
+  );
+
+  const userPosts = mock.history.post.filter((r) => r.url === "/users");
+  expect(JSON.parse(userPosts[0].data)).toEqual({ name: "Alice" });
+  expect(JSON.parse(userPosts[1].data)).toEqual({ name: "Bob" });
+});

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -115,7 +115,7 @@ export default function HomePage() {
         mb="md"
         value={search}
         onChange={(e) => setSearch(e.currentTarget.value)}
-        clearable
+        /* Clear button removed due to type incompatibility */
       />
 
       <TopUpModal


### PR DESCRIPTION
## Summary
- support entering multiple users on AddUserPage
- show a notification for each user created
- provide test coverage for adding multiple users
- fix typecheck failure by removing unsupported clearable prop

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68429458943c83269d10127b7040a208