### PR TITLE
Redesigned stats page

### DIFF
--- a/frontend/components/Stats/AllTimeLeaderboard.tsx
+++ b/frontend/components/Stats/AllTimeLeaderboard.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { Card, ScrollArea, Table, Title } from "@mantine/core";
+import api from "../../api/api";
+import { Person } from "../../types";
+import classes from "../../styles/StatsPage.module.css";
+
+export function AllTimeLeaderboard() {
+  const [entries, setEntries] = useState<Person[]>([]);
+
+  useEffect(() => {
+    api.get<Person[]>("/users").then((r) => setEntries(r.data));
+  }, []);
+
+  const sorted = [...entries].sort((a, b) => b.total_drinks - a.total_drinks);
+
+  return (
+    <Card
+      shadow="sm"
+      p="md"
+      radius="md"
+      withBorder
+      className={classes.leaderboardCard}
+    >
+      <Title order={4} mb="sm">
+        All Time
+      </Title>
+      <ScrollArea>
+        <Table striped highlightOnHover>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Name</th>
+              <th>Drinks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((u, i) => (
+              <tr key={u.id}>
+                <td>{i + 1}</td>
+                <td>{u.name}</td>
+                <td>{u.total_drinks.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </ScrollArea>
+    </Card>
+  );
+}

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -1,43 +1,50 @@
 import React from "react";
-import { Container, Grid, Paper } from "@mantine/core";
+import { Container, Paper, Tabs, Title } from "@mantine/core";
 import { OverallStats } from "../components/Stats/OverallStats";
 import { MonthlyLeaderboard } from "../components/Stats/MonthlyLeaderboard";
 import { YearlyLeaderboard } from "../components/Stats/YearlyLeaderboard";
+import { AllTimeLeaderboard } from "../components/Stats/AllTimeLeaderboard";
 import { UserInsightPanel } from "../components/Stats/UserInsightPanel";
 import classes from "../styles/StatsPage.module.css";
 
 function StatsPage() {
   return (
-    <Container py="md" className={classes.statsContainer}>
-      {/* Overall Stats - wrapped in Paper */}
-      <Paper withBorder shadow="sm" p="md" mb="lg">
+    <Container size="xl" py="md" className={classes.statsContainer}>
+      <Title order={1} mb="sm">
+        Stats
+      </Title>
+
+      <Title order={2} mt="sm" mb="xs">
+        Leaderboard
+      </Title>
+      <Tabs defaultValue="monthly" variant="outline" radius="xs">
+        <Tabs.List mb="md">
+          <Tabs.Tab value="monthly">Monthly</Tabs.Tab>
+          <Tabs.Tab value="yearly">Yearly</Tabs.Tab>
+          <Tabs.Tab value="all">All Time</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="monthly">
+          <MonthlyLeaderboard />
+        </Tabs.Panel>
+        <Tabs.Panel value="yearly">
+          <YearlyLeaderboard />
+        </Tabs.Panel>
+        <Tabs.Panel value="all">
+          <AllTimeLeaderboard />
+        </Tabs.Panel>
+      </Tabs>
+
+      <Title order={2} mt="lg" mb="sm">
+        Your Insights
+      </Title>
+      <Paper withBorder shadow="sm" p="md" mb="md">
         <OverallStats />
       </Paper>
-
-      {/* Leaderboards Section */}
       <Paper
         withBorder
         shadow="sm"
         p="md"
-        mb="lg"
-        className={classes.leaderboardSection}
-      >
-        <Grid>
-          <Grid.Col span={{ base: 12, md: 6 }}>
-            <MonthlyLeaderboard />
-          </Grid.Col>
-          <Grid.Col span={{ base: 12, md: 6 }}>
-            <YearlyLeaderboard />
-          </Grid.Col>
-        </Grid>
-      </Paper>
-
-      {/* User Insight Panel Section */}
-      <Paper
-        withBorder
-        shadow="sm"
-        p="md"
-        mt="lg"
         className={classes.userInsightSection}
       >
         <UserInsightPanel />

--- a/frontend/pages/__tests__/StatsPage.test.tsx
+++ b/frontend/pages/__tests__/StatsPage.test.tsx
@@ -1,0 +1,26 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent } from "../../test-utils";
+import StatsPage from "../StatsPage";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+});
+
+test("navigates leaderboard tabs", async () => {
+  mock.onGet("/stats/monthly_leaderboard").reply(200, []);
+  mock.onGet("/stats/yearly_leaderboard").reply(200, []);
+  mock.onGet("/users").reply(200, []);
+  render(<StatsPage />);
+
+  // Monthly is default
+  expect(await screen.findByText(/this month/i)).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("tab", { name: /yearly/i }));
+  expect(await screen.findByText(/this year/i)).toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("tab", { name: /all time/i }));
+  expect(await screen.findByText(/all time/i)).toBeInTheDocument();
+});

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -7,6 +7,17 @@ export default function Document() {
     <Html lang="en" {...mantineHtmlProps}>
       <Head>
         <ColorSchemeScript localStorageKey={colorSchemeStorageKey} />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="stylesheet"
+          as="style"
+          href="https://fonts.googleapis.com/css2?display=swap&family=Noto+Sans:wght@400;500;700;900&family=Plus+Jakarta+Sans:wght@400;500;700;800"
+          onLoad="this.rel='stylesheet'"
+        />
         <script
           dangerouslySetInnerHTML={{
             __html: `(() => { const t = localStorage.getItem('${colorSchemeStorageKey}') || 'light'; document.documentElement.setAttribute('data-theme', t); })();`,

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -12,9 +12,7 @@
 
 body {
   margin: 0;
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: var(--color-bg);
@@ -35,9 +33,9 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Greycliff CF", sans-serif; /* Common Mantine heading font */
-  font-weight: 600;
-  color: #1c1c1c; /* Darker heading color */
+  font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;
+  font-weight: 700;
+  color: #1c1c1c;
 }
 
 /* Layout Utilities */


### PR DESCRIPTION
## Summary
- restyle StatsPage with tabs for monthly/yearly/all time leaderboards
- add AllTimeLeaderboard component
- integrate Google Fonts
- apply new fonts via global CSS
- add unit test for tab switching

## Testing
- `npm test` *(fails: `next` not found)*
- `npm run jest` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842960c3c7483269fddde07c4cb997f