### PR TITLE
Refactor admin page with CSS modules

### DIFF
--- a/frontend/pages/AdminPage.tsx
+++ b/frontend/pages/AdminPage.tsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useState } from "react";
+import Head from "next/head";
+import api from "../api/api";
+import { Person } from "../types";
+import { AdminGate } from "../components/Admin/AdminGate";
+import classes from "../styles/AdminPage.module.css";
+
+interface Payment {
+  id: number;
+  mollie_id: string;
+  person_id: number;
+  amount: number;
+  status: string;
+  created_at: string;
+}
+
+export default function AdminPage() {
+  const [isAuth, setIsAuth] = useState(false);
+  const [users, setUsers] = useState<Person[]>([]);
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [tab, setTab] = useState<"users" | "payments">("users");
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    if (!isAuth) {
+      return;
+    }
+    api.get<Person[]>("/users").then((r) => setUsers(r.data));
+    api.get<Payment[]>("/payments").then((r) => setPayments(r.data));
+  }, [isAuth]);
+
+  const filteredUsers = users.filter((u) =>
+    u.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <>
+      <Head>
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?display=swap&family=Epilogue:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900"
+        />
+      </Head>
+      <AdminGate onAuthenticated={() => setIsAuth(true)}>
+        <div className={classes.root}>
+          <aside className={classes.sidebar}>
+            <h1 className={classes.logo}>DrinkTracker</h1>
+            <nav className={classes.nav}>
+              <span className={classes.menuItem}>Home</span>
+              <span className={classes.menuItem}>Drinks</span>
+              <span className={classes.menuItem}>Users</span>
+              <span className={classes.menuItem}>Payments</span>
+              <span className={`${classes.menuItem} ${classes.menuItemActive}`}>
+                Settings
+              </span>
+            </nav>
+          </aside>
+          <main className={classes.content}>
+            <header className={classes.header}>
+              <p className={classes.title}>Settings</p>
+            </header>
+            <div className={classes.tabs} role="tablist">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "users"}
+                className={`${classes.tab} ${tab === "users" ? classes.tabActive : ""}`}
+                onClick={() => setTab("users")}
+              >
+                Users
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "payments"}
+                className={`${classes.tab} ${tab === "payments" ? classes.tabActive : ""}`}
+                onClick={() => setTab("payments")}
+              >
+                Payments
+              </button>
+            </div>
+
+            {tab === "users" && (
+              <>
+                <h2 className={classes.sectionHeading}>Manage Users</h2>
+                <div className={classes.searchArea}>
+                  <label className={classes.searchLabel}>
+                    <input
+                      className={classes.searchInput}
+                      placeholder="Search users"
+                      value={search}
+                      onChange={(e) => setSearch(e.currentTarget.value)}
+                    />
+                  </label>
+                </div>
+                <div className={classes.tableContainer}>
+                  <div className={classes.tableWrapper}>
+                    <table className={classes.table}>
+                      <thead>
+                        <tr>
+                          <th className={classes.colName}>Name</th>
+                          <th className={classes.colEmail}>Email</th>
+                          <th className={classes.colBalance}>Balance</th>
+                          <th className={classes.colActions}>Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {filteredUsers.map((u) => (
+                          <tr key={u.id}>
+                            <td className={classes.colName}>{u.name}</td>
+                            <td className={classes.colEmail}>-</td>
+                            <td className={classes.colBalance}>${u.balance}</td>
+                            <td
+                              className={`${classes.colActions} ${classes.actionCell}`}
+                            >
+                              Edit
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+                <div className={classes.addUser}>
+                  <button type="button" className={classes.addUserButton}>
+                    Add User
+                  </button>
+                </div>
+              </>
+            )}
+
+            {tab === "payments" && (
+              <>
+                <h2 className={classes.sectionHeading}>Payments</h2>
+                <div className={classes.tableContainer}>
+                  <div className={classes.tableWrapper}>
+                    <table className={classes.table}>
+                      <thead>
+                        <tr>
+                          <th>ID</th>
+                          <th>User ID</th>
+                          <th>Amount</th>
+                          <th>Status</th>
+                          <th>Date</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {payments.map((p) => (
+                          <tr key={p.id}>
+                            <td>{p.id}</td>
+                            <td>{p.person_id}</td>
+                            <td>{p.amount}</td>
+                            <td>{p.status}</td>
+                            <td>
+                              {p.created_at
+                                ? new Date(p.created_at).toLocaleDateString()
+                                : "-"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </>
+            )}
+          </main>
+        </div>
+      </AdminGate>
+    </>
+  );
+}

--- a/frontend/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/pages/__tests__/AddUserPage.test.tsx
@@ -7,6 +7,7 @@ const mock = new MockAdapter(api);
 
 afterEach(() => {
   mock.reset();
+  mock.restore();
   localStorage.clear();
 });
 

--- a/frontend/pages/__tests__/AdminPage.test.tsx
+++ b/frontend/pages/__tests__/AdminPage.test.tsx
@@ -1,0 +1,45 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent, waitFor } from "../../test-utils";
+import AdminPage from "../AdminPage";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  mock.restore();
+  localStorage.clear();
+});
+
+test("tab switching and user search", async () => {
+  mock.onPost("/auth/login").reply(200, { access_token: "tok" });
+  mock.onGet("/users").reply(200, [
+    { id: 1, name: "Ethan", balance: 25, total_drinks: 0 },
+    { id: 2, name: "Olivia", balance: 10, total_drinks: 0 },
+  ]);
+  mock.onGet("/payments").reply(200, []);
+
+  render(<AdminPage />);
+
+  await userEvent.type(
+    screen.getByPlaceholderText(/enter admin password/i),
+    "pass",
+  );
+  await userEvent.click(screen.getByRole("button", { name: /login/i }));
+
+  await waitFor(() => screen.getByText(/manage users/i));
+  const searchInput = screen.getByPlaceholderText(/search users/i);
+  await userEvent.type(searchInput, "olivia");
+  expect(screen.getByText(/Olivia/i)).toBeInTheDocument();
+  expect(screen.queryByText(/Ethan/i)).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getAllByRole("tab", { name: /payments/i })[0]);
+  expect(
+    screen.getByRole("heading", { name: /payments/i }),
+  ).toBeInTheDocument();
+
+  await userEvent.click(screen.getAllByRole("tab", { name: /users/i })[0]);
+  expect(
+    screen.getByRole("heading", { name: /manage users/i }),
+  ).toBeInTheDocument();
+});

--- a/frontend/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/pages/__tests__/SettingsPage.test.tsx
@@ -7,6 +7,7 @@ const mock = new MockAdapter(api);
 
 afterEach(() => {
   mock.reset();
+  mock.restore();
   localStorage.clear();
 });
 

--- a/frontend/pages/__tests__/StatsPage.test.tsx
+++ b/frontend/pages/__tests__/StatsPage.test.tsx
@@ -7,20 +7,20 @@ const mock = new MockAdapter(api);
 
 afterEach(() => {
   mock.reset();
+  mock.restore();
 });
 
 test("navigates leaderboard tabs", async () => {
-  mock.onGet("/stats/monthly_leaderboard").reply(200, []);
-  mock.onGet("/stats/yearly_leaderboard").reply(200, []);
+  mock.onGet(/\/stats\//).reply(200, []);
   mock.onGet("/users").reply(200, []);
   render(<StatsPage />);
 
   // Monthly is default
-  expect(await screen.findByText(/this month/i)).toBeInTheDocument();
+  expect(await screen.findAllByText(/this month/i)).toHaveLength(2);
 
   await userEvent.click(screen.getByRole("tab", { name: /yearly/i }));
-  expect(await screen.findByText(/this year/i)).toBeInTheDocument();
+  expect(await screen.findAllByText(/this year/i)).toHaveLength(2);
 
   await userEvent.click(screen.getByRole("tab", { name: /all time/i }));
-  expect(await screen.findByText(/all time/i)).toBeInTheDocument();
+  expect(await screen.findAllByText(/all time/i)).toHaveLength(2);
 });

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -16,7 +16,10 @@ export default function Document() {
           rel="stylesheet"
           as="style"
           href="https://fonts.googleapis.com/css2?display=swap&family=Noto+Sans:wght@400;500;700;900&family=Plus+Jakarta+Sans:wght@400;500;700;800"
-          onLoad="this.rel='stylesheet'"
+          onLoad={(e) => {
+            const target = e.currentTarget as HTMLLinkElement;
+            target.rel = "stylesheet";
+          }}
         />
         <script
           dangerouslySetInnerHTML={{

--- a/frontend/styles/AdminPage.module.css
+++ b/frontend/styles/AdminPage.module.css
@@ -1,0 +1,183 @@
+.root {
+  --primary-color: #359dff;
+  --text-color: #0c151d;
+  --secondary-color: #4574a1;
+  --border-color: #cddcea;
+  --bg-color: #f8fafc;
+
+  font-family: "Epilogue", "Noto Sans", sans-serif;
+  background-color: var(--bg-color);
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 20rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: var(--bg-color);
+}
+
+.logo {
+  color: var(--text-color);
+  font-size: 1rem;
+  font-weight: 500;
+  margin-bottom: 1rem;
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  color: var(--text-color);
+}
+
+.menuItemActive {
+  background-color: #e6edf4;
+  border-radius: 0.5rem;
+}
+
+.content {
+  flex: 1;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: 1rem;
+}
+
+.title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.tabs {
+  display: flex;
+  gap: 2rem;
+  border-bottom: 1px solid var(--border-color);
+  padding: 0 1rem;
+}
+
+.tab {
+  padding: 1rem 0;
+  border-bottom: 3px solid transparent;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--secondary-color);
+  cursor: pointer;
+}
+
+.tabActive {
+  border-color: var(--primary-color);
+  color: var(--text-color);
+}
+
+.sectionHeading {
+  padding: 1rem;
+  padding-bottom: 0.75rem;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.searchArea {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 1rem;
+  max-width: 480px;
+}
+
+.searchInput {
+  flex: 1;
+  height: 3.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+
+.tableContainer {
+  padding: 1rem;
+}
+
+.tableWrapper {
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  background-color: var(--bg-color);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.75rem;
+  text-align: left;
+}
+
+th {
+  color: var(--text-color);
+  font-weight: 500;
+  font-size: 0.875rem;
+}
+
+td {
+  color: var(--secondary-color);
+  font-size: 0.875rem;
+}
+
+tbody tr + tr {
+  border-top: 1px solid var(--border-color);
+}
+
+.actionCell {
+  color: var(--secondary-color);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.addUser {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem;
+}
+
+.addUserButton {
+  background-color: var(--primary-color);
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+@media (width <= 640px) {
+  .colEmail {
+    display: none;
+  }
+}
+
+@media (width <= 480px) {
+  .colBalance {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- implement new `AdminPage` UI using CSS modules
- style page with `AdminPage.module.css`
- add tests for admin tab behavior and user search
- mock Axios adapters correctly and fix existing tests
- patch `_document.tsx` for TS compliance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684299e8ae5083268a908606fb7097d7