### PR TITLE
Ensure stable user ordering

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -7,7 +7,8 @@ from mollie.api.client import Client as MollieClient
 import os
 
 def get_persons(db: Session):
-    return db.query(models.Person).all()
+    """Return all persons sorted by name for deterministic ordering."""
+    return db.query(models.Person).order_by(models.Person.name.asc()).all()
 
 
 def create_person(db: Session, person: schemas.PersonCreate):

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -73,3 +73,14 @@ def test_create_user_without_optional_fields(client):
     data = resp.json()
     assert data["avatar_url"] is None
     assert data["nickname"] is None
+
+
+def test_users_sorted_by_name(client):
+    client.post("/users", json={"name": "Charlie"})
+    client.post("/users", json={"name": "Alice"})
+    client.post("/users", json={"name": "Bob"})
+
+    resp = client.get("/users")
+    assert resp.status_code == 200
+    names = [u["name"] for u in resp.json()]
+    assert names == sorted(names)

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Container,
   TextInput,
@@ -24,23 +24,18 @@ export default function HomePage() {
   const [modalOpened, setModalOpened] = useState(false);
   const [topUpUser, setTopUpUser] = useState<Person | null>(null);
   const [amount, setAmount] = useState<number>(5);
-  const originalOrderRef = useRef<number[]>([]);
 
   const [notifications, setNotifications] = useState<DrinkNotification[]>([]);
 
   useEffect(() => {
     api.get<Person[]>("/users").then((r) => {
       setUsers(r.data);
-      originalOrderRef.current = r.data.map((u) => u.id);
     });
   }, []);
 
-  const fetchUsersSorted = async () => {
+  const fetchUsers = async () => {
     const updatedUsers = (await api.get<Person[]>("/users")).data;
-    const sorted = originalOrderRef.current.map(
-      (id) => updatedUsers.find((u) => u.id === id)!,
-    );
-    setUsers(sorted);
+    setUsers(updatedUsers);
   };
 
   const handleDrink = async (userId: number) => {
@@ -68,7 +63,7 @@ export default function HomePage() {
     ]);
 
     await api.post(`/users/${userId}/drinks`);
-    await fetchUsersSorted();
+    await fetchUsers();
   };
 
   const handleUndoDrink = async (notif: DrinkNotification) => {
@@ -79,7 +74,7 @@ export default function HomePage() {
       total_drinks: freshUser.total_drinks - 1,
     });
 
-    await fetchUsersSorted();
+    await fetchUsers();
     setNotifications((prev) => prev.filter((n) => n.id !== notif.id));
   };
 


### PR DESCRIPTION
## Summary
- sort users by name on the backend
- simplify Home page user fetching logic
- test that `/users` returns a sorted list

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `PYTHONPATH=backend pytest backend/tests/test_auth.py -q`
- `PYTHONPATH=backend pytest backend/tests/test_leaderboard.py -q`
- `PYTHONPATH=backend pytest backend/tests/test_user_stats.py -q`
- `PYTHONPATH=backend pytest backend/tests/test_users.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6842a17cdc488326b61bc6570dbcb89f