### PR TITLE
Enhance navbar logo styling

### DIFF
--- a/frontend/components/Navbar/NavbarSimple.module.css
+++ b/frontend/components/Navbar/NavbarSimple.module.css
@@ -72,4 +72,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  color: var(--color-logo);
 }

--- a/frontend/components/Navbar/NavbarSimple.tsx
+++ b/frontend/components/Navbar/NavbarSimple.tsx
@@ -35,7 +35,7 @@ export default function NavbarSimpleContent() {
           style={{ width: 32, height: 32, marginRight: 8 }}
         />
         <Text fw={700} size="lg, xl" className={classes.logo}>
-          Drink Tracker
+          DrinkTracker+
         </Text>
       </Group>
 

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -2,12 +2,14 @@
   --color-bg: #f1f3f5;
   --color-text: #212529;
   --color-border: #ced4da;
+  --color-logo: #1c7ed6;
 }
 
 [data-theme="dark"] {
   --color-bg: #1a1b1e;
   --color-text: #c1c2c5;
   --color-border: #373a40;
+  --color-logo: #4dabf7;
 }
 
 body {


### PR DESCRIPTION
## Summary
- add `--color-logo` variables to global styles for light/dark themes
- style `.logo` text color using the new token
- update logo text to "DrinkTracker+"

## Testing
- `yarn test --silent` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6842b965a36c83268d317547747c20eb