### PR TITLE
Add Peak Thirst Hours insight

### DIFF
--- a/frontend/components/Stats/PeakThirstHoursChart.tsx
+++ b/frontend/components/Stats/PeakThirstHoursChart.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import { BarChart } from "@mantine/charts";
+import { Loader, Text, Title, useMantineTheme } from "@mantine/core";
+import api from "../../api/api";
+import { PeakThirstHoursResponse } from "../../types/insights";
+
+interface PeakThirstHoursChartProps {
+  userIds: number[];
+  idToName: Record<number, string>;
+}
+
+export function PeakThirstHoursChart({ userIds, idToName }: PeakThirstHoursChartProps) {
+  const theme = useMantineTheme();
+  const [data, setData] = useState<PeakThirstHoursResponse>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (userIds.length === 0) {
+      setData([]);
+      return;
+    }
+    setLoading(true);
+    api
+      .get<PeakThirstHoursResponse>("/insights/peak_thirst_hours", {
+        params: { user_ids: userIds.join(",") },
+      })
+      .then((res) => setData(res.data))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [userIds]);
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (userIds.length === 0) {
+    return <Text c="dimmed">Select users to view chart.</Text>;
+  }
+
+  const seriesNames = data.map((d) => idToName[d.userId] || `User ${d.userId}`);
+
+  const chartData = Array.from({ length: 24 }, (_, hour) => {
+    const entry: Record<string, number | string> = { x: hour };
+    data.forEach((d, idx) => {
+      entry[seriesNames[idx]] = d.hours[hour] ?? 0;
+    });
+    return entry;
+  });
+
+  const series = seriesNames.map((name, idx) => ({
+    name,
+    color: theme.colors[theme.primaryColor][(idx * 3) % 10],
+  }));
+
+  return (
+    <div>
+      <Title order={4} mb="sm">
+        Peak Thirst Hours
+      </Title>
+      <BarChart data={chartData} dataKey="x" series={series} h={300} withLegend />
+    </div>
+  );
+}
+
+export default PeakThirstHoursChart;

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,8 +1,17 @@
 import React, { useState, useEffect } from "react";
-import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
+import {
+  Select,
+  MultiSelect,
+  Text,
+  Title,
+  SimpleGrid,
+  Card,
+  Loader,
+} from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
+import PeakThirstHoursChart from "./PeakThirstHoursChart";
 
 interface UserStatsData {
   drinks_last_30_days: number;
@@ -16,6 +25,7 @@ export function UserInsightPanel() {
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [loadingUsers, setLoadingUsers] = useState<boolean>(true);
+  const [selectedChartUsers, setSelectedChartUsers] = useState<string[]>([]);
 
   // Fetch all users for the dropdown
   useEffect(() => {
@@ -37,6 +47,8 @@ export function UserInsightPanel() {
         setLoadingUsers(false);
       });
   }, []);
+
+  const idToName = Object.fromEntries(users.map((u) => [Number(u.value), u.label]));
 
   // Fetch stats for the selected user
   useEffect(() => {
@@ -86,6 +98,18 @@ export function UserInsightPanel() {
         }
       />
 
+      <MultiSelect
+        label="Compare Users"
+        placeholder="Select users"
+        data={users}
+        value={selectedChartUsers}
+        onChange={setSelectedChartUsers}
+        searchable
+        clearable
+        disabled={loadingUsers}
+        mb="lg"
+      />
+
       {loading && <Loader />}
 
       {!loading && !selectedUserId && (
@@ -132,6 +156,11 @@ export function UserInsightPanel() {
         // This case might happen briefly if user name isn't found before mock data is set
         <Text c="dimmed">Loading user data...</Text>
       )}
+
+      <PeakThirstHoursChart
+        userIds={selectedChartUsers.map((id) => parseInt(id, 10))}
+        idToName={idToName}
+      />
     </div>
   );
 }

--- a/frontend/types/insights.ts
+++ b/frontend/types/insights.ts
@@ -1,0 +1,6 @@
+export interface PeakThirstHoursResult {
+  userId: number;
+  hours: number[]; // length 24, count of drinks per hour
+}
+
+export type PeakThirstHoursResponse = PeakThirstHoursResult[];


### PR DESCRIPTION
## Summary
- aggregate drink counts by hour for a list of users
- expose `/insights/peak_thirst_hours` FastAPI endpoint
- show "Peak Thirst Hours" chart in stats panel
- add chart component using Mantine BarChart
- define insight response types

## Testing
- `yarn test` *(fails: project not installed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6842c5dca9c483268dbab4eb0894c73c