### PR TITLE
Add hydration streaks chart and API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -229,6 +229,11 @@ def yearly_leaderboard(db: Session = Depends(get_db)):
     return [{"id": r.id, "name": r.name, "drinks": int(r.drinks)} for r in results]
 
 
+@app.get("/stats/longest_hydration_streaks")
+def longest_hydration_streaks(limit: int = 10, db: Session = Depends(get_db)):
+    return crud.get_longest_hydration_streaks(db, limit)
+
+
 
 @app.get("/users/{user_id}/stats")
 def user_stats(user_id: int, db: Session = Depends(get_db)):

--- a/backend/tests/test_longest_streaks.py
+++ b/backend/tests/test_longest_streaks.py
@@ -1,0 +1,88 @@
+import types
+import sys
+from datetime import datetime, timedelta
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from unittest import mock
+import pytest
+
+# Stub mollie client to avoid optional dependency in tests
+mollie = types.ModuleType("mollie")
+api_mod = types.ModuleType("api")
+client_mod = types.ModuleType("client")
+client_mod.Client = object
+api_mod.client = client_mod
+mollie.api = api_mod
+sys.modules.setdefault("mollie", mollie)
+sys.modules.setdefault("mollie.api", api_mod)
+sys.modules.setdefault("mollie.api.client", client_mod)
+
+
+test_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+with mock.patch("sqlalchemy.create_engine", lambda *a, **k: test_engine):
+    from app.main import app, get_db
+    from app import models
+    from app.database import Base
+    from app.main import longest_hydration_streaks
+
+
+def create_test_app():
+    TestingSessionLocal = sessionmaker(bind=test_engine, autoflush=False, autocommit=False)
+    Base.metadata.drop_all(bind=test_engine)
+    Base.metadata.create_all(bind=test_engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    client = TestClient(app)
+    return client, TestingSessionLocal
+
+from fastapi.testclient import TestClient
+
+
+def setup_test_data(SessionLocal):
+    with SessionLocal() as db:
+        alice = models.Person(name="Alice")
+        bob = models.Person(name="Bob")
+        db.add_all([alice, bob])
+        db.commit()
+        db.refresh(alice)
+        db.refresh(bob)
+
+        start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=5)
+        events = [
+            models.DrinkEvent(person_id=alice.id, timestamp=start),
+            models.DrinkEvent(person_id=alice.id, timestamp=start + timedelta(days=1)),
+            models.DrinkEvent(person_id=alice.id, timestamp=start + timedelta(days=2)),
+            models.DrinkEvent(person_id=bob.id, timestamp=start + timedelta(days=1)),
+            models.DrinkEvent(person_id=bob.id, timestamp=start + timedelta(days=3)),
+        ]
+        db.add_all(events)
+        db.commit()
+
+
+@pytest.fixture
+def client_session():
+    client, SessionLocal = create_test_app()
+    setup_test_data(SessionLocal)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def test_longest_hydration_streaks(client_session):
+    client = client_session
+    resp = client.get("/stats/longest_hydration_streaks")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["name"] == "Alice" and data[0]["streak"] == 3

--- a/frontend/components/Navbar/NavbarSimple.tsx
+++ b/frontend/components/Navbar/NavbarSimple.tsx
@@ -15,7 +15,11 @@ import classes from "./NavbarSimple.module.css";
 
 const mainLinks = [
   { href: "/", label: "Drinks", icon: IconBeer },
-  { href: "/LeaderBoardPage", label: "Leaderboard", icon: IconDeviceDesktopAnalytics },
+  {
+    href: "/LeaderBoardPage",
+    label: "Leaderboard",
+    icon: IconDeviceDesktopAnalytics,
+  },
   { href: "/StatsPage", label: "Stats", icon: IconDeviceDesktopAnalytics },
 ];
 const footerLinks = [

--- a/frontend/components/Stats/LongestHydrationStreakChart.tsx
+++ b/frontend/components/Stats/LongestHydrationStreakChart.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { BarChart } from "@mantine/charts";
+import { Card, Title, Text, Loader } from "@mantine/core";
+import api from "../../api/api";
+
+interface StreakEntry {
+  id: number;
+  name: string;
+  streak: number;
+}
+
+export function LongestHydrationStreakChart() {
+  const [data, setData] = useState<StreakEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<StreakEntry[]>("/stats/longest_hydration_streaks")
+      .then((r) => setData(r.data))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (data.length === 0) {
+    return <Text c="dimmed">No streak data available.</Text>;
+  }
+
+  const chartData = data.map((d) => ({
+    name: d.name,
+    "Streak Length": d.streak,
+  }));
+
+  return (
+    <Card shadow="sm" p="md" radius="md" withBorder>
+      <Title order={4} mb="sm">
+        Longest Hydration Streaks
+      </Title>
+      <BarChart
+        h={300}
+        data={chartData}
+        dataKey="name"
+        series={[{ name: "Streak Length", color: "blue.6" }]}
+      />
+    </Card>
+  );
+}
+
+export default LongestHydrationStreakChart;

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -3,6 +3,7 @@ import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
+import LongestHydrationStreakChart from "./LongestHydrationStreakChart";
 
 interface UserStatsData {
   drinks_last_30_days: number;
@@ -128,6 +129,7 @@ export function UserInsightPanel() {
           </SimpleGrid>
         </>
       )}
+      <LongestHydrationStreakChart />
       {!loading && selectedUserId && !userData && !selectedUserName && (
         // This case might happen briefly if user name isn't found before mock data is set
         <Text c="dimmed">Loading user data...</Text>

--- a/frontend/components/Stats/__tests__/LongestHydrationStreakChart.test.tsx
+++ b/frontend/components/Stats/__tests__/LongestHydrationStreakChart.test.tsx
@@ -1,0 +1,22 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../../api/api";
+import { render, screen } from "../../../test-utils";
+import LongestHydrationStreakChart from "../LongestHydrationStreakChart";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  mock.restore();
+});
+
+test("renders streak chart", async () => {
+  mock
+    .onGet("/stats/longest_hydration_streaks")
+    .reply(200, [{ id: 1, name: "Alice", streak: 5 }]);
+  render(<LongestHydrationStreakChart />);
+  expect(
+    await screen.findByText(/Longest Hydration Streaks/i),
+  ).toBeInTheDocument();
+  expect(await screen.findByText(/Alice/)).toBeInTheDocument();
+});

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -27,9 +27,7 @@ function StatsPage() {
 
   return (
     <Container size="xl" py="md" className={classes.statsContainer}>
-      <Title>
-        Your Insights
-      </Title>
+      <Title>Your Insights</Title>
       <Paper
         withBorder
         shadow="sm"


### PR DESCRIPTION
## Summary
- compute longest consecutive drink streaks on the backend
- expose new `/stats/longest_hydration_streaks` endpoint
- render `LongestHydrationStreakChart` with Mantine `BarChart`
- show the chart in `UserInsightPanel`
- cover the new chart with a basic test

## Testing
- `npm --prefix frontend run prettier:check`
- `npm --prefix frontend test` *(fails: `next` not found)*
- `pytest -q` *(fails: missing fastapi/sqlalchemy dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6842c5f8230c8326953b6463a2579052