### PR TITLE
Add Social Sip Score chart

### DIFF
--- a/frontend/components/Stats/SocialSipScoreChart.tsx
+++ b/frontend/components/Stats/SocialSipScoreChart.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { Card, Loader, Text, Title } from "@mantine/core";
+import { BarChart } from "@mantine/charts";
+
+interface PairFrequency {
+  pairLabel: string;
+  count: number;
+}
+
+export function SocialSipScoreChart() {
+  const [data, setData] = useState<PairFrequency[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/insights/social-sip-score")
+      .then((res) => res.json())
+      .then((d: PairFrequency[]) => setData(d))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <Card shadow="sm" p="md" radius="md" withBorder>
+        <Loader />
+      </Card>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <Card shadow="sm" p="md" radius="md" withBorder>
+        <Text>No overlapping drink logs found.</Text>
+      </Card>
+    );
+  }
+
+  return (
+    <Card shadow="sm" p="md" radius="md" withBorder>
+      <Title order={4} mb="sm">
+        Social Sip Score
+      </Title>
+      <BarChart
+        h={300}
+        data={data}
+        dataKey="pairLabel"
+        series={[{ name: "count", color: "blue.6" }]}
+      />
+    </Card>
+  );
+}
+
+export default SocialSipScoreChart;

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -3,6 +3,7 @@ import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
+import SocialSipScoreChart from "./SocialSipScoreChart";
 
 interface UserStatsData {
   drinks_last_30_days: number;
@@ -132,6 +133,8 @@ export function UserInsightPanel() {
         // This case might happen briefly if user name isn't found before mock data is set
         <Text c="dimmed">Loading user data...</Text>
       )}
+
+      <SocialSipScoreChart />
     </div>
   );
 }

--- a/frontend/lib/insights/socialSipScore.ts
+++ b/frontend/lib/insights/socialSipScore.ts
@@ -1,0 +1,61 @@
+import { Pool } from "pg";
+
+export interface PairFrequency {
+  pairLabel: string;
+  count: number;
+}
+
+const pool = new Pool({
+  host: process.env.POSTGRES_HOST || "localhost",
+  port: Number(process.env.POSTGRES_PORT) || 5432,
+  user: process.env.POSTGRES_USER || "postgres",
+  password: process.env.POSTGRES_PASSWORD || "postgres",
+  database: process.env.POSTGRES_DB || "drinktracker",
+});
+
+export async function getSocialSipScore(topN = 10): Promise<PairFrequency[]> {
+  const eventsRes = await pool.query<{ person_id: number; timestamp: string }>(
+    "SELECT person_id, timestamp FROM drink_events",
+  );
+  const personsRes = await pool.query<{ id: number; name: string }>(
+    "SELECT id, name FROM persons",
+  );
+
+  const nameMap = new Map<number, string>();
+  personsRes.rows.forEach((p) => nameMap.set(p.id, p.name));
+
+  const buckets: Record<number, number[]> = {};
+  for (const ev of eventsRes.rows) {
+    const date = new Date(ev.timestamp);
+    const bucket = Math.floor(date.getTime() / (5 * 60 * 1000));
+    buckets[bucket] = buckets[bucket] || [];
+    if (!buckets[bucket].includes(ev.person_id)) {
+      buckets[bucket].push(ev.person_id);
+    }
+  }
+
+  const pairCounts: Record<string, number> = {};
+  for (const ids of Object.values(buckets)) {
+    if (ids.length < 2) continue;
+    ids.sort((a, b) => a - b);
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const key = `${ids[i]}-${ids[j]}`;
+        pairCounts[key] = (pairCounts[key] || 0) + 1;
+      }
+    }
+  }
+
+  const result: PairFrequency[] = Object.entries(pairCounts).map(
+    ([key, count]) => {
+      const [id1, id2] = key.split("-").map(Number);
+      const name1 = nameMap.get(id1) || `User ${id1}`;
+      const name2 = nameMap.get(id2) || `User ${id2}`;
+      const pairLabel = `${name1} & ${name2}`;
+      return { pairLabel, count };
+    },
+  );
+
+  result.sort((a, b) => b.count - a.count);
+  return result.slice(0, topN);
+}

--- a/frontend/pages/api/insights/social-sip-score.ts
+++ b/frontend/pages/api/insights/social-sip-score.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSocialSipScore } from "../../../lib/insights/socialSipScore";
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const data = await getSocialSipScore();
+    res.status(200).json(data);
+  } catch (error) {
+    console.error("social sip score error", error);
+    res.status(500).json({ message: "Failed to compute social sip score" });
+  }
+}


### PR DESCRIPTION
## Summary
- compute social sip score data on server via Postgres
- expose API route `/api/insights/social-sip-score`
- add `SocialSipScoreChart` component with Mantine `BarChart`
- show new chart in user insights panel

## Testing
- `npm run prettier:check`
- `npm test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c627a60c8326909676ede65b9d27