### PR TITLE
Implement Chug of Fame chart

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,6 +2,10 @@ import os
 from fastapi.testclient import TestClient
 from jose import jwt
 from passlib.context import CryptContext
+import sys
+
+# Ensure backend/app is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
 os.environ["ADMIN_SECRET_KEY"] = "testsecret"
 os.environ.setdefault("POSTGRES_USER", "test")

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -2,9 +2,13 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, and_
 from sqlalchemy.orm import sessionmaker
+import os
+import sys
+
+# Ensure backend/app is in path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from sqlalchemy.pool import StaticPool
 from datetime import timedelta
-import sys
 import types
 from unittest import mock
 

--- a/frontend/components/Stats/ChugOfFameChart.tsx
+++ b/frontend/components/Stats/ChugOfFameChart.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import { BarChart } from "@mantine/charts";
+import { Card, Loader, Text, Title } from "@mantine/core";
+import api from "../../api/api";
+
+interface ChugEntry {
+  id: number;
+  name: string;
+  fastest_seconds: number;
+}
+
+export function ChugOfFameChart() {
+  const [data, setData] = useState<ChugEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<ChugEntry[]>("/stats/chug_of_fame")
+      .then((r) => {
+        const sorted = [...r.data].sort(
+          (a, b) => a.fastest_seconds - b.fastest_seconds,
+        );
+        setData(sorted);
+      })
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <Card shadow="sm" p="md" radius="md" withBorder>
+        <Loader />
+      </Card>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <Card shadow="sm" p="md" radius="md" withBorder>
+        <Text c="dimmed">No drink data available.</Text>
+      </Card>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    user: d.name,
+    seconds: d.fastest_seconds,
+  }));
+
+  return (
+    <Card shadow="sm" p="md" radius="md" withBorder>
+      <Title order={4} mb="sm">
+        Chug of Fame
+      </Title>
+      <BarChart
+        h={300}
+        data={chartData}
+        dataKey="user"
+        series={[{ name: "Fastest Time (s)", valueKey: "seconds" }]}
+      />
+    </Card>
+  );
+}
+
+export default ChugOfFameChart;

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -3,6 +3,7 @@ import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
+import ChugOfFameChart from "./ChugOfFameChart";
 
 interface UserStatsData {
   drinks_last_30_days: number;
@@ -132,6 +133,8 @@ export function UserInsightPanel() {
         // This case might happen briefly if user name isn't found before mock data is set
         <Text c="dimmed">Loading user data...</Text>
       )}
+
+      <ChugOfFameChart />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `/stats/chug_of_fame` endpoint to compute minimum drink interval per user
- show "Chug of Fame" bar chart with Mantine
- integrate chart into UserInsightPanel
- extend tests for new endpoint
- ensure test helpers import backend package properly

## Testing
- `pytest backend/tests/test_user_stats.py::test_chug_of_fame -q`
- `pytest backend/tests/test_user_stats.py::test_user_stats_last_30_days -q`


------
https://chatgpt.com/codex/tasks/task_b_6842c60be5a8832680f2e3933bd1ec23