### PR TITLE
Add monthly drink volume chart

### DIFF
--- a/frontend/components/Stats/MonthlyDrinkVolumeChart.tsx
+++ b/frontend/components/Stats/MonthlyDrinkVolumeChart.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { BarChart } from "@mantine/charts";
+import { Center, Loader, Text } from "@mantine/core";
+import type { MonthlyVolumeEntry } from "../../types/insights";
+
+interface Props {
+  userIds: number[];
+}
+
+interface ChartDatum {
+  month: string;
+  [key: string]: number | string;
+}
+
+export default function MonthlyDrinkVolumeChart({ userIds }: Props) {
+  const [data, setData] = useState<MonthlyVolumeEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!userIds.length) {
+      setData([]);
+      return;
+    }
+    setLoading(true);
+    fetch("/api/insights/monthly-drink-volume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userIds }),
+    })
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [userIds]);
+
+  if (!userIds.length) {
+    return <Text c="dimmed">Select users to view data</Text>;
+  }
+
+  if (loading) {
+    return (
+      <Center h={200}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (!data.length) {
+    return <Text c="dimmed">No data available</Text>;
+  }
+
+  const months = Array.from(new Set(data.map((d) => d.month))).sort();
+  const seriesIds = Array.from(new Set(data.map((d) => d.userId)));
+
+  const chartData: ChartDatum[] = months.map((m) => {
+    const obj: ChartDatum = { month: m };
+    seriesIds.forEach((id) => {
+      const entry = data.find((d) => d.month === m && d.userId === id);
+      obj[`user-${id}`] = entry ? entry.count : 0;
+    });
+    return obj;
+  });
+
+  const series = seriesIds.map((id) => ({
+    name: `User ${id}`,
+    valueKey: `user-${id}`,
+  }));
+
+  return (
+    <BarChart
+      h={300}
+      data={chartData}
+      dataKey="month"
+      series={series}
+      withLegend
+    />
+  );
+}

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,5 +1,14 @@
 import React, { useState, useEffect } from "react";
-import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
+import {
+  Select,
+  MultiSelect,
+  Text,
+  Title,
+  SimpleGrid,
+  Card,
+  Loader,
+} from "@mantine/core";
+import MonthlyDrinkVolumeChart from "./MonthlyDrinkVolumeChart";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
@@ -12,6 +21,7 @@ interface UserStatsData {
 export function UserInsightPanel() {
   const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [chartUsers, setChartUsers] = useState<string[]>([]);
   const [userData, setUserData] = useState<UserStatsData | null>(null);
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -85,6 +95,20 @@ export function UserInsightPanel() {
           loadingUsers ? "Loading users..." : "No users found"
         }
       />
+      <MultiSelect
+        label="Compare Users"
+        placeholder="Pick users to compare"
+        data={users}
+        value={chartUsers}
+        onChange={setChartUsers}
+        searchable
+        clearable
+        disabled={loadingUsers}
+        mb="lg"
+        nothingFoundMessage={
+          loadingUsers ? "Loading users..." : "No users found"
+        }
+      />
 
       {loading && <Loader />}
 
@@ -132,6 +156,8 @@ export function UserInsightPanel() {
         // This case might happen briefly if user name isn't found before mock data is set
         <Text c="dimmed">Loading user data...</Text>
       )}
+
+      <MonthlyDrinkVolumeChart userIds={chartUsers.map(Number)} />
     </div>
   );
 }

--- a/frontend/lib/insights/monthlyDrinkVolume.ts
+++ b/frontend/lib/insights/monthlyDrinkVolume.ts
@@ -1,0 +1,45 @@
+import { Client } from "pg";
+import { startOfMonth, subMonths, formatISO } from "date-fns";
+
+export interface MonthlyDrinkVolumeRow {
+  userId: number;
+  month: string; // ISO string YYYY-MM
+  count: number;
+}
+
+function getClient() {
+  const {
+    POSTGRES_USER,
+    POSTGRES_PASSWORD,
+    POSTGRES_DB,
+    POSTGRES_HOST,
+    POSTGRES_PORT,
+  } = process.env;
+  const connectionString = `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}`;
+  return new Client({ connectionString });
+}
+
+export async function fetchMonthlyDrinkVolume(
+  userIds: number[],
+): Promise<MonthlyDrinkVolumeRow[]> {
+  if (!userIds.length) return [];
+  const client = getClient();
+  await client.connect();
+  try {
+    const startDate = startOfMonth(subMonths(new Date(), 5));
+    const res = await client.query(
+      `SELECT person_id AS "userId",
+              to_char(date_trunc('month', timestamp), 'YYYY-MM') AS month,
+              COUNT(*)::int AS count
+         FROM drink_events
+        WHERE person_id = ANY($1)
+          AND timestamp >= $2
+        GROUP BY person_id, month
+        ORDER BY month`,
+      [userIds, startDate],
+    );
+    return res.rows as MonthlyDrinkVolumeRow[];
+  } finally {
+    await client.end();
+  }
+}

--- a/frontend/pages/api/insights/monthly-drink-volume.ts
+++ b/frontend/pages/api/insights/monthly-drink-volume.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchMonthlyDrinkVolume } from "../../../lib/insights/monthlyDrinkVolume";
+import type { MonthlyDrinkVolumeRow } from "../../../lib/insights/monthlyDrinkVolume";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<MonthlyDrinkVolumeRow[] | { message: string }>,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
+  const { userIds } = req.body as { userIds?: number[] };
+  if (!Array.isArray(userIds) || userIds.some((id) => typeof id !== "number")) {
+    return res.status(400).json({ message: "Invalid userIds" });
+  }
+
+  try {
+    const data = await fetchMonthlyDrinkVolume(userIds);
+    return res.status(200).json(data);
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
+}

--- a/frontend/types/insights.ts
+++ b/frontend/types/insights.ts
@@ -1,0 +1,5 @@
+export interface MonthlyVolumeEntry {
+  userId: number;
+  month: string; // YYYY-MM
+  count: number;
+}


### PR DESCRIPTION
## Summary
- add chart component to visualize monthly drink volumes for users
- provide API route and DB handler for monthly volumes
- extend user insight panel with multi-select and chart
- define insight types

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `npm test --silent` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842c5e853a883268f907edb80976ff9