### PR TITLE
Fix duplicate multiselect in UserInsightPanel

### DIFF
--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -14,7 +14,7 @@ export function UserInsightPanel() {
   const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [loadingUsers, setLoadingUsers] = useState<boolean>(true);
-  const [selectedChartUsers, setSelectedChartUsers] = useState<string[]>([]);
+  const [chartUsers, setChartUsers] = useState<string[]>([]);
 
   // Fetch all users for the dropdown
   useEffect(() => {
@@ -89,19 +89,6 @@ export function UserInsightPanel() {
           loadingUsers ? "Loading users..." : "No users found"
         }
       />
-
-      <MultiSelect
-        label="Compare Users"
-        placeholder="Select users"
-        data={users}
-        value={selectedChartUsers}
-        onChange={setSelectedChartUsers}
-        searchable
-        clearable
-        disabled={loadingUsers}
-        mb="lg"
-      />
-
       {!loading && !selectedUserId && (
         <Text c="dimmed">Select a user to see their insights.</Text>
       )}
@@ -141,10 +128,9 @@ export function UserInsightPanel() {
       )}
 
       <PeakThirstHoursChart
-        userIds={selectedChartUsers.map((id) => parseInt(id, 10))}
+        userIds={chartUsers.map((id) => parseInt(id, 10))}
         idToName={idToName}
-      /> 
-      
+      />
 
       <MonthlyDrinkVolumeChart userIds={chartUsers.map(Number)} />
     </div>


### PR DESCRIPTION
## Summary
- remove duplicate `<MultiSelect>` in `UserInsightPanel`
- rename chart user state and wire it to both charts

## Testing
- `npm run test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ceee4ad083268bf2ce1e44025203