### PR TITLE
Simplify user insights panel

### DIFF
--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,60 +1,32 @@
-import React, { useState, useEffect } from "react";
-import { Select, Text, Title, Card, Loader, Table } from "@mantine/core";
-import { Person, BuddyScore } from "../../types";
+import React, { useEffect, useState } from "react";
+import { Select, Text, Title } from "@mantine/core";
+import { Person } from "../../types";
 import api from "../../api/api";
-import classes from "../../styles/StatsPage.module.css";
 import PeakThirstHoursChart from "./PeakThirstHoursChart";
-import LongestHydrationStreakChart from "./LongestHydrationStreakChart";
-import SocialSipChart from "./SocialSipChart";
+import MonthlyDrinkVolumeChart from "./MonthlyDrinkVolumeChart";
+import classes from "../../styles/StatsPage.module.css";
 
 export function UserInsightPanel() {
   const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
-  const [buddyScores, setBuddyScores] = useState<BuddyScore[] | null>(null);
-  const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [loadingUsers, setLoadingUsers] = useState<boolean>(true);
-  const [selectedChartUsers, setSelectedChartUsers] = useState<string[]>([]);
+  const [loadingUsers, setLoadingUsers] = useState(true);
 
-  // Fetch all users for the dropdown
+  // load users for dropdown
   useEffect(() => {
     setLoadingUsers(true);
     api
       .get<Person[]>("/users")
-      .then((response) => {
-        const transformedUsers = response.data.map((user) => ({
-          value: user.id.toString(),
-          label: user.name,
-        }));
-        setUsers(transformedUsers);
+      .then((res) => {
+        setUsers(
+          res.data.map((u) => ({ value: u.id.toString(), label: u.name })),
+        );
       })
-      .catch((_error) => {
-        // Optionally set an error state here
-        // console.error("Error fetching users:", error);
-      })
-      .finally(() => {
-        setLoadingUsers(false);
-      });
+      .finally(() => setLoadingUsers(false));
   }, []);
 
-  // Fetch buddy scores for the selected user
-  useEffect(() => {
-    if (selectedUserId) {
-      setLoading(true);
-      setBuddyScores(null);
-
-      const selectedUser = users.find((u) => u.value === selectedUserId);
-      setSelectedUserName(selectedUser ? selectedUser.label : null);
-
-      api
-        .get<BuddyScore[]>(`/users/${selectedUserId}/social_sip_scores`)
-        .then((res) => setBuddyScores(res.data))
-        .finally(() => setLoading(false));
-    } else {
-      setBuddyScores(null);
-      setSelectedUserName(null);
-    }
-  }, [selectedUserId, users]);
+  const idToName = Object.fromEntries(
+    users.map((u) => [parseInt(u.value, 10), u.label]),
+  );
 
   return (
     <div className={classes.userInsightPanel}>
@@ -75,78 +47,20 @@ export function UserInsightPanel() {
           loadingUsers ? "Loading users..." : "No users found"
         }
       />
-      <MultiSelect
-        label="Compare Users"
-        placeholder="Pick users to compare"
-        data={users}
-        value={chartUsers}
-        onChange={setChartUsers}
-        searchable
-        clearable
-        disabled={loadingUsers}
-        mb="lg"
-        nothingFoundMessage={
-          loadingUsers ? "Loading users..." : "No users found"
-        }
-      />
 
-      <MultiSelect
-        label="Compare Users"
-        placeholder="Select users"
-        data={users}
-        value={selectedChartUsers}
-        onChange={setSelectedChartUsers}
-        searchable
-        clearable
-        disabled={loadingUsers}
-        mb="lg"
-      />
-
-      {!loading && !selectedUserId && (
+      {!selectedUserId && (
         <Text c="dimmed">Select a user to see their insights.</Text>
       )}
 
-      {!loading && selectedUserId && buddyScores && selectedUserName && (
+      {selectedUserId && (
         <>
-          <Title order={4} mb="sm">
-            Top buddies for {selectedUserName}
-          </Title>
-          <Card withBorder p="md" radius="md" className={classes.userStatsCard}>
-            {buddyScores.length === 0 && (
-              <Text c="dimmed">No buddy data available.</Text>
-            )}
-            {buddyScores.length > 0 && (
-              <Table highlightOnHover verticalSpacing="sm">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th style={{ textAlign: "right" }}>Score</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {buddyScores.map((b) => (
-                    <tr key={b.buddy_id}>
-                      <td>{b.buddy_name}</td>
-                      <td style={{ textAlign: "right" }}>{b.score}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </Table>
-            )}
-          </Card>
+          <PeakThirstHoursChart
+            userIds={[parseInt(selectedUserId, 10)]}
+            idToName={idToName}
+          />
+          <MonthlyDrinkVolumeChart userIds={[parseInt(selectedUserId, 10)]} />
         </>
       )}
-      {!loading && selectedUserId && !buddyScores && !selectedUserName && (
-        <Text c="dimmed">Loading user data...</Text>
-      )}
-
-      <PeakThirstHoursChart
-        userIds={selectedChartUsers.map((id) => parseInt(id, 10))}
-        idToName={idToName}
-      /> 
-      
-
-      <MonthlyDrinkVolumeChart userIds={chartUsers.map(Number)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove buddy charts and multi-selects from the stats panel
- allow selecting a single user to display charts

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for '@testing-library/jest-dom')*
- `npm test` *(fails: next lint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842cef7da408326bfe4eab00f6f2e07