### PR TITLE
Fix leaderboard page test

### DIFF
--- a/frontend/pages/__tests__/LeaderBoardPage.test.tsx
+++ b/frontend/pages/__tests__/LeaderBoardPage.test.tsx
@@ -1,7 +1,7 @@
 import MockAdapter from "axios-mock-adapter";
 import api from "../../api/api";
 import { render, screen, userEvent } from "../../test-utils";
-import StatsPage from "../StatsPage";
+import LeaderBoardPage from "../LeaderBoardPage";
 
 const mock = new MockAdapter(api);
 
@@ -13,7 +13,7 @@ afterEach(() => {
 test("navigates leaderboard tabs", async () => {
   mock.onGet(/\/stats\//).reply(200, []);
   mock.onGet("/users").reply(200, []);
-  render(<StatsPage />);
+  render(<LeaderBoardPage />);
 
   // Monthly is default
   expect((await screen.findAllByText(/this month/i)).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- rename `StatsPage.test.tsx` to `LeaderBoardPage.test.tsx`
- update import and component reference to target the leaderboard page

## Testing
- `npm run jest pages/__tests__/LeaderBoardPage.test.tsx` *(fails: other tests / lint in `npm run test`)*

------
https://chatgpt.com/codex/tasks/task_b_6842ceeb562c83269c23d6d951ddf74a