### PR TITLE
Add missing styles for Stats pages

### DIFF
--- a/frontend/styles/StatsPage.module.css
+++ b/frontend/styles/StatsPage.module.css
@@ -34,3 +34,35 @@
     }
   }
 }
+
+/* Container wrapping the entire stats page */
+.statsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+}
+
+/* Paper section that contains the user insight charts */
+.userInsightSection {
+  border-radius: var(--mantine-radius-md);
+  box-shadow: var(--mantine-shadow-sm);
+}
+
+/* Shared card styling for leaderboard widgets */
+.leaderboardCard {
+  border: 1px solid var(--mantine-color-gray-2);
+  border-radius: var(--mantine-radius-md);
+}
+
+/* Wrapper for the user insight panel component */
+.userInsightPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+}
+
+/* Styling for user statistics table cards */
+.userStatsCard {
+  border: 1px solid var(--mantine-color-gray-2);
+  border-radius: var(--mantine-radius-md);
+}


### PR DESCRIPTION
## Summary
- flesh out `StatsPage.module.css` with styles used across stats pages

## Testing
- `npm run lint` *(fails: no-duplicate-imports, unused-vars, etc.)*
- `npm run test` *(fails: code style issues found by Prettier)*

------
https://chatgpt.com/codex/tasks/task_b_6842ceed0d108326b64a2df6097926bd