### PR TITLE
Fix mapping for user names in insights charts

### DIFF
--- a/frontend/components/Stats/PeakThirstHoursChart.tsx
+++ b/frontend/components/Stats/PeakThirstHoursChart.tsx
@@ -9,7 +9,10 @@ interface PeakThirstHoursChartProps {
   idToName: Record<number, string>;
 }
 
-export function PeakThirstHoursChart({ userIds, idToName }: PeakThirstHoursChartProps) {
+export function PeakThirstHoursChart({
+  userIds,
+  idToName,
+}: PeakThirstHoursChartProps) {
   const theme = useMantineTheme();
   const [data, setData] = useState<PeakThirstHoursResponse>([]);
   const [loading, setLoading] = useState(false);
@@ -57,7 +60,13 @@ export function PeakThirstHoursChart({ userIds, idToName }: PeakThirstHoursChart
       <Title order={4} mb="sm">
         Peak Thirst Hours
       </Title>
-      <BarChart data={chartData} dataKey="x" series={series} h={300} withLegend />
+      <BarChart
+        data={chartData}
+        dataKey="x"
+        series={series}
+        h={300}
+        withLegend
+      />
     </div>
   );
 }

--- a/frontend/components/Stats/SocialSipChart.tsx
+++ b/frontend/components/Stats/SocialSipChart.tsx
@@ -54,4 +54,3 @@ export function SocialSipChart({ userId }: Props) {
 }
 
 export default SocialSipChart;
-

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,5 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { Select, Text, Title, Card, Loader, MultiSelect, Table } from "@mantine/core";
+import React, { useState, useEffect, useMemo } from "react";
+import {
+  Select,
+  Text,
+  Title,
+  Card,
+  Loader,
+  MultiSelect,
+  Table,
+} from "@mantine/core";
 import { Person, BuddyScore } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
@@ -15,6 +23,14 @@ export function UserInsightPanel() {
   const [loading, setLoading] = useState<boolean>(false);
   const [loadingUsers, setLoadingUsers] = useState<boolean>(true);
   const [chartUsers, setChartUsers] = useState<string[]>([]);
+
+  const idToName = useMemo(() => {
+    const map: Record<number, string> = {};
+    users.forEach((u) => {
+      map[parseInt(u.value, 10)] = u.label;
+    });
+    return map;
+  }, [users]);
 
   // Fetch all users for the dropdown
   useEffect(() => {

--- a/frontend/components/Stats/__tests__/SocialSipChart.test.tsx
+++ b/frontend/components/Stats/__tests__/SocialSipChart.test.tsx
@@ -11,10 +11,7 @@ afterEach(() => {
 });
 
 test("renders social sip data", async () => {
-  mock.onGet("/users/1/buddies").reply(200, [
-    { id: 2, name: "Bob", count: 3 },
-  ]);
+  mock.onGet("/users/1/buddies").reply(200, [{ id: 2, name: "Bob", count: 3 }]);
   render(<SocialSipChart userId="1" />);
   expect(await screen.findByText(/Bob/)).toBeInTheDocument();
 });
-

--- a/frontend/lib/insights/socialSipScore.ts
+++ b/frontend/lib/insights/socialSipScore.ts
@@ -22,7 +22,9 @@ export async function getSocialSipScore(topN = 10): Promise<PairFrequency[]> {
   );
 
   const nameMap = new Map<number, string>();
-  personsRes.rows.forEach((p: { id: number; name: string }) => nameMap.set(p.id, p.name));
+  personsRes.rows.forEach((p: { id: number; name: string }) =>
+    nameMap.set(p.id, p.name),
+  );
 
   const buckets: Record<number, number[]> = {};
   for (const ev of eventsRes.rows) {


### PR DESCRIPTION
## Summary
- map user names with `useMemo` in `UserInsightPanel`
- format components with Prettier for linting

## Testing
- `npx prettier --check "**/*.{ts,tsx}"`
- `npm test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d051e0708326a1ec3a4837cb6a09