### PR TITLE
Update user insights to remove comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ logs/
 *.sql
 *.dump
 frontend/.next/*
+.stylelintcache
+frontend/tsconfig.tsbuildinfo

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,12 +1,5 @@
 import React, { useState, useEffect } from "react";
-import {
-  Select,
-  Text,
-  Title,
-  SimpleGrid,
-  Card,
-  Loader,
-} from "@mantine/core";
+import { Select, Text, Title, SimpleGrid, Card, Loader } from "@mantine/core";
 import { Person } from "../../types";
 import api from "../../api/api";
 import classes from "../../styles/StatsPage.module.css";
@@ -47,7 +40,7 @@ export function UserInsightPanel() {
       })
       .catch((_error) => {
         // Optionally set an error state here
-        // console.error("Error fetching users:", error); 
+        // console.error("Error fetching users:", error);
       })
       .finally(() => {
         setLoadingUsers(false);

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -1,46 +1,11 @@
-import React, { useState, useEffect } from "react";
-import { Container, Grid, Paper } from "@mantine/core"; // Removed Text, Flex, added Grid, Paper
-import api from "../api/api"; // ✅ correct path from 'pages' dir
-import { Person } from "../types";
-import { OverallStats } from "../components/Stats/OverallStats";
-import { MonthlyLeaderboard } from "../components/Stats/MonthlyLeaderboard";
-import { YearlyLeaderboard } from "../components/Stats/YearlyLeaderboard";
-import { UserInsightPanel } from "../components/Stats/UserInsightPanel"; // New import
+import React from "react";
+import { Container, Paper } from "@mantine/core";
+import { UserInsightPanel } from "../components/Stats/UserInsightPanel";
 import classes from "../styles/StatsPage.module.css"; // Import CSS module
 
 function StatsPage() {
-  const [users, setUsers] = useState<Person[]>([]);
-
-  useEffect(() => {
-    api.get<Person[]>("/users").then((r) => setUsers(r.data));
-  }, []);
-
   return (
     <Container py="md" className={classes.statsContainer}>
-      {/* Overall Stats - wrapped in Paper */}
-      <Paper withBorder shadow="sm" p="md" mb="lg">
-        <OverallStats />
-      </Paper>
-
-      {/* Leaderboards Section */}
-      <Paper
-        withBorder
-        shadow="sm"
-        p="md"
-        mb="lg"
-        className={classes.leaderboardSection}
-      >
-        <Grid>
-          <Grid.Col span={{ base: 12, md: 6 }}>
-            <MonthlyLeaderboard users={users} />
-          </Grid.Col>
-          <Grid.Col span={{ base: 12, md: 6 }}>
-            <YearlyLeaderboard users={users} />
-          </Grid.Col>
-        </Grid>
-      </Paper>
-
-      {/* User Insight Panel Section */}
       <Paper
         withBorder
         shadow="sm"


### PR DESCRIPTION
## Summary
- stop showing overall leaderboards on the stats page
- keep only the user insights panel
- ignore stylelint cache files
- reformat user insight panel with Prettier

## Testing
- `npm run jest`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6842d3f4f6908326a2397edc385d42a1