### PR TITLE
Add user drink hourly API and chart

### DIFF
--- a/frontend/components/Stats/PeakThirstHours.tsx
+++ b/frontend/components/Stats/PeakThirstHours.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+import { BarChart } from "@mantine/charts";
+import { Card, Loader, Text, Title } from "@mantine/core";
+
+export function toPercentages(counts: number[]): number[] {
+  const total = counts.reduce((a, b) => a + b, 0);
+  if (total === 0) return counts.map(() => 0);
+  return counts.map((c) => Math.round((c / total) * 100));
+}
+
+interface Props {
+  userId: string | null;
+}
+
+export default function PeakThirstHours({ userId }: Props) {
+  const [data, setData] = useState<number[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    setLoading(true);
+    fetch(`/api/users/${userId}/drinks-per-hour`)
+      .then((res) => res.json())
+      .then((d) => setData(Array.isArray(d.hours) ? d.hours : []))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  if (!userId) {
+    return <Text c="dimmed">Select a user to view data.</Text>;
+  }
+
+  if (loading) {
+    return <Loader />;
+  }
+
+  if (!data.length) {
+    return <Text c="dimmed">No drink data.</Text>;
+  }
+
+  const percentages = toPercentages(data);
+  const chartData = percentages.map((p, h) => ({ hour: h.toString(), pct: p }));
+
+  return (
+    <Card shadow="sm" p="md" radius="md" withBorder>
+      <Title order={5} mb="sm">
+        Peak Thirst Hours
+      </Title>
+      <BarChart
+        h={200}
+        data={chartData}
+        dataKey="hour"
+        series={[{ name: "%", valueKey: "pct", color: "blue.6" }]}
+      />
+    </Card>
+  );
+}

--- a/frontend/components/Stats/UserInsightPanel.tsx
+++ b/frontend/components/Stats/UserInsightPanel.tsx
@@ -1,48 +1,26 @@
-import React, { useState, useEffect, useMemo } from "react";
-import { Select, Text, Title, SimpleGrid, MultiSelect, Card, Loader } from "@mantine/core";
-import { Person } from "../../types";
+import React, { useEffect, useState } from "react";
+import { Select } from "@mantine/core";
 import api from "../../api/api";
-import PeakThirstHoursChart from "./PeakThirstHoursChart";
+import { Person } from "../../types";
 import MonthlyDrinkVolumeChart from "./MonthlyDrinkVolumeChart";
+import PeakThirstHours from "./PeakThirstHours";
 import classes from "../../styles/StatsPage.module.css";
-
-// Define BuddyScore type if not imported from elsewhere
-type BuddyScore = {
-  // Replace these fields with the actual structure as needed
-  userId: number;
-  score: number;
-};
 
 export function UserInsightPanel() {
   const [users, setUsers] = useState<{ value: string; label: string }[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
-  const [buddyScores, setBuddyScores] = useState<BuddyScore[] | null>(null);
-  const [selectedUserName, setSelectedUserName] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [chartUsers, setChartUsers] = useState<string[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(true);
 
-  const idToName = useMemo(() => {
-    const map: Record<number, string> = {};
-    users.forEach((u) => {
-      map[parseInt(u.value, 10)] = u.label;
-    });
-    return map;
-  }, [users]);
-
-  // Fetch all users for the dropdown
   useEffect(() => {
     setLoadingUsers(true);
     api
       .get<Person[]>("/users")
-      .then((res) => {
+      .then((res) =>
         setUsers(
           res.data.map((u) => ({ value: u.id.toString(), label: u.name })),
-        );
-      })
-      .finally(() => {
-        setLoadingUsers(false);
-      });
+        ),
+      )
+      .finally(() => setLoadingUsers(false));
   }, []);
 
   return (
@@ -62,12 +40,11 @@ export function UserInsightPanel() {
         }
       />
       {selectedUserId && (
-         <MonthlyDrinkVolumeChart userIds={[parseInt(selectedUserId, 10)]} />
-
-        <PeakThirstHoursChart 
+        <>
+          <MonthlyDrinkVolumeChart userIds={[parseInt(selectedUserId, 10)]} />
+          <PeakThirstHours userId={selectedUserId} />
+        </>
       )}
-
-
     </div>
   );
 }

--- a/frontend/components/Stats/__tests__/PeakThirstHours.test.tsx
+++ b/frontend/components/Stats/__tests__/PeakThirstHours.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "../../../test-utils";
+import PeakThirstHours, { toPercentages } from "../PeakThirstHours";
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ hours: Array(24).fill(1) }),
+    } as Response),
+  ) as jest.Mock;
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockReset();
+});
+
+test("converts counts to percentages", () => {
+  expect(toPercentages([1, 1, 2])).toEqual([25, 25, 50]);
+});
+
+test("renders chart after fetch", async () => {
+  render(<PeakThirstHours userId="1" />);
+  expect(global.fetch).toHaveBeenCalledWith("/api/users/1/drinks-per-hour");
+  expect(await screen.findByText(/Peak Thirst Hours/i)).toBeInTheDocument();
+});

--- a/frontend/lib/insights/drinksPerHour.ts
+++ b/frontend/lib/insights/drinksPerHour.ts
@@ -1,0 +1,40 @@
+import { Client } from "pg";
+
+function getClient() {
+  const {
+    POSTGRES_USER,
+    POSTGRES_PASSWORD,
+    POSTGRES_DB,
+    POSTGRES_HOST,
+    POSTGRES_PORT,
+  } = process.env;
+  const connectionString = `postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}`;
+  return new Client({ connectionString });
+}
+
+export interface DrinksPerHourResponse {
+  userId: number;
+  hours: number[];
+}
+
+export async function fetchDrinksPerHour(userId: number): Promise<number[]> {
+  const client = getClient();
+  await client.connect();
+  try {
+    const res = await client.query(
+      `SELECT extract(hour from timestamp) as hour, count(*)::int as count
+       FROM drink_events
+       WHERE person_id = $1
+       GROUP BY hour
+       ORDER BY hour`,
+      [userId],
+    );
+    const counts = Array(24).fill(0);
+    for (const row of res.rows as { hour: string; count: number }[]) {
+      counts[parseInt(row.hour, 10)] = row.count;
+    }
+    return counts;
+  } finally {
+    await client.end();
+  }
+}

--- a/frontend/pages/api/users/[id]/drinks-per-hour.ts
+++ b/frontend/pages/api/users/[id]/drinks-per-hour.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { fetchDrinksPerHour } from "../../../../lib/insights/drinksPerHour";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { id } = req.query;
+  if (typeof id !== "string") {
+    return res.status(400).json({ message: "Invalid user id" });
+  }
+  const userId = parseInt(id, 10);
+  if (Number.isNaN(userId)) {
+    return res.status(400).json({ message: "Invalid user id" });
+  }
+  try {
+    const hours = await fetchDrinksPerHour(userId);
+    return res.status(200).json({ userId, hours });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ message: "Internal Server Error" });
+  }
+}

--- a/frontend/pages/api/users/__tests__/drinks-per-hour.test.ts
+++ b/frontend/pages/api/users/__tests__/drinks-per-hour.test.ts
@@ -1,0 +1,30 @@
+import handler from "../[id]/drinks-per-hour";
+import { fetchDrinksPerHour } from "../../../../lib/insights/drinksPerHour";
+
+// polyfill for pg which expects TextEncoder
+(global as any).TextEncoder = require("util").TextEncoder;
+
+jest.mock("../../../../lib/insights/drinksPerHour", () => ({
+  fetchDrinksPerHour: jest.fn(),
+}));
+
+const mockedFetch = fetchDrinksPerHour as jest.MockedFunction<
+  typeof fetchDrinksPerHour
+>;
+
+describe("drinks-per-hour api", () => {
+  test("returns hourly counts", async () => {
+    mockedFetch.mockResolvedValue(Array(24).fill(1));
+
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const req = { query: { id: "5" } } as any;
+    const res = { status } as any;
+
+    await handler(req, res);
+
+    expect(mockedFetch).toHaveBeenCalledWith(5);
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ userId: 5, hours: Array(24).fill(1) });
+  });
+});


### PR DESCRIPTION
## Summary
- provide a backend helper to fetch drinks per hour
- expose `/api/users/[id]/drinks-per-hour` endpoint in Next.js API
- create `PeakThirstHours` chart component using fetched data
- wire PeakThirstHours chart into `UserInsightPanel`
- add tests for new API endpoint, percent conversion, and chart rendering

## Testing
- `npx jest components/Stats/__tests__/PeakThirstHours.test.tsx pages/api/users/__tests__/drinks-per-hour.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_6842d8cb8ae88326a72cef2b05f7e239