### PR TITLE
Improve search by nickname on drink page

### DIFF
--- a/frontend/components/UserCard/UserCard.tsx
+++ b/frontend/components/UserCard/UserCard.tsx
@@ -12,7 +12,7 @@ import classes from "./UserCardImage.module.css";
 import { Person } from "../../types";
 
 interface UserCardProps {
-  user: Person & { nickname?: string };
+  user: Person;
   onDrink: () => void;
   onTopUp: () => void;
   onChangeAvatar?: (file: File | null) => void;

--- a/frontend/pages/__tests__/HomePage.test.tsx
+++ b/frontend/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,29 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent } from "../../test-utils";
+import HomePage from "../index";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  mock.restore();
+});
+
+test("searches users by nickname", async () => {
+  mock.onGet("/users").reply(200, [
+    { id: 1, name: "Alice", nickname: "Al", balance: 5, total_drinks: 0 },
+    { id: 2, name: "Bob", balance: 5, total_drinks: 0 },
+  ]);
+
+  render(<HomePage />);
+
+  // Wait for users to load
+  await screen.findByText(/Alice/);
+
+  const input = screen.getByPlaceholderText(/search users/i);
+  await userEvent.clear(input);
+  await userEvent.type(input, "al");
+  expect(screen.getByText(/Alice/)).toBeInTheDocument();
+  expect(screen.queryByText(/Bob/)).not.toBeInTheDocument();
+});

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -58,7 +58,7 @@ export default function HomePage() {
     await api.post(`/users/${userId}/avatar`, form, {
       headers: { "Content-Type": "multipart/form-data" },
     });
-    await fetchUsersSorted();
+    await fetchUsers();
   };
 
   const handleDrink = async (userId: number) => {
@@ -121,8 +121,11 @@ export default function HomePage() {
     window.location.href = data.checkoutUrl;
   };
 
-  const filtered = users.filter((u) =>
-    u.name.toLowerCase().includes(search.toLowerCase()),
+  const searchLower = search.toLowerCase();
+  const filtered = users.filter(
+    (u) =>
+      u.name.toLowerCase().includes(searchLower) ||
+      (u.nickname ?? "").toLowerCase().includes(searchLower),
   );
 
   if (isMobile) {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -4,6 +4,7 @@ export interface Person {
   balance: number;
   total_drinks: number;
   avatarUrl?: string; // Added avatarUrl property
+  nickname?: string | null;
 }
 
 export interface TopUpResponse {


### PR DESCRIPTION
## Summary
- extend `Person` type with `nickname`
- handle `nickname` in user cards
- allow searching by nickname on the drink page
- test nickname search

## Testing
- `PYTHONPATH=. pytest -q` *(fails: TypeError and AttributeError)*
- `npm test --silent` *(fails: Prettier syntax error)*

------
https://chatgpt.com/codex/tasks/task_b_6842da49efb483268269db222d40182c