### PR TITLE
Fix avatar display by adding absolute URL resolver

### DIFF
--- a/frontend/components/UserCard/UserCard.tsx
+++ b/frontend/components/UserCard/UserCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@mantine/core";
 import classes from "./UserCardImage.module.css";
 import { Person } from "../../types";
+import { resolveAvatarUrl } from "../../lib/resolveAvatarUrl";
 
 interface UserCardProps {
   user: Person;
@@ -43,7 +44,7 @@ export function UserCardImage({
       {/* Avatar */}
       <div className={classes.avatarWrapper}>
         <Avatar
-          src={user.avatarUrl}
+          src={resolveAvatarUrl(user.avatarUrl)}
           size={80}
           radius={80}
           mx="auto"

--- a/frontend/lib/resolveAvatarUrl.ts
+++ b/frontend/lib/resolveAvatarUrl.ts
@@ -1,0 +1,8 @@
+export function resolveAvatarUrl(avatarUrl?: string): string | undefined {
+  if (!avatarUrl) return undefined;
+  try {
+    return new URL(avatarUrl, process.env.NEXT_PUBLIC_API_URL || "").href;
+  } catch {
+    return avatarUrl;
+  }
+}

--- a/frontend/pages/AvatarPage.tsx
+++ b/frontend/pages/AvatarPage.tsx
@@ -12,6 +12,7 @@ import {
 import { IconUpload } from "@tabler/icons-react";
 import api from "../api/api";
 import { Person } from "../types";
+import { resolveAvatarUrl } from "../lib/resolveAvatarUrl";
 import classes from "../styles/AvatarPage.module.css";
 
 export default function AvatarPage() {
@@ -55,7 +56,7 @@ export default function AvatarPage() {
           {users.map((user) => (
             <Table.Tr key={user.id}>
               <Table.Td>
-                <Avatar src={user.avatarUrl} radius="xl" />
+                <Avatar src={resolveAvatarUrl(user.avatarUrl)} radius="xl" />
               </Table.Td>
               <Table.Td>
                 <Text>{user.name}</Text>


### PR DESCRIPTION
## Summary
- add helper `resolveAvatarUrl` to prefix avatar paths
- use `resolveAvatarUrl` in `UserCard` and `AvatarPage` to show avatars correctly

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: DetachedInstanceError)*
- `npm test --silent` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842de50335c832698545113ed087cd4