### PR TITLE
Return camelCase avatarUrl

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,7 +41,11 @@ app.add_middleware(
 )
 
 
-@app.get("/users", response_model=list[schemas.Person])
+@app.get(
+    "/users",
+    response_model=list[schemas.PersonOut],
+    response_model_by_alias=False,
+)
 def read_users(db: Session = Depends(get_db)):
     return crud.get_persons(db)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,6 +22,19 @@ class Person(PersonBase):
         allow_population_by_field_name = True
 
 
+class PersonOut(BaseModel):
+    id: int
+    name: str
+    avatarUrl: str | None = Field(default=None, alias="avatar_url")
+    nickname: str | None = None
+    balance: Decimal
+    total_drinks: int
+
+    class Config:
+        orm_mode = True
+        allow_population_by_field_name = True
+
+
 class DrinkEvent(BaseModel):
     id: int
     person_id: int

--- a/frontend/pages/AvatarPage.tsx
+++ b/frontend/pages/AvatarPage.tsx
@@ -19,7 +19,12 @@ export default function AvatarPage() {
   const [users, setUsers] = useState<Person[]>([]);
 
   useEffect(() => {
-    api.get<Person[]>("/users").then((r) => setUsers(r.data));
+    api.get<Person[]>("/users").then((r) => {
+      setUsers(r.data);
+      // Reload or rebuild the React app and inspect the console to ensure
+      // user.avatarUrl is now populated and avatars render correctly.
+      // console.log(r.data.map((u) => u.avatarUrl));
+    });
   }, []);
 
   const handleUpload = async (userId: number, file: File | null) => {


### PR DESCRIPTION
## Summary
- add `PersonOut` response schema aliasing `avatarUrl` to `avatar_url`
- use the new schema for `/users` and disable alias names in the response
- remind developers to reload the frontend and log `avatarUrl`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6842e807e92c8326814095cad427e6c5