### PR TITLE
Fix mobile avatar display

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Person } from "../../types";
 import { Paper, Group, Avatar, Text, Stack, Box } from "@mantine/core";
+import { resolveAvatarUrl } from "../../lib/resolveAvatarUrl";
 // Removed ThemeIcon and IconCash as they are not used in the final example from the prompt
 // but good to keep in mind for future enhancements.
 
@@ -14,7 +15,12 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
   return (
     <Paper shadow="md" p="lg" radius="md" withBorder>
       <Stack align="center" gap="md">
-        <Avatar size="xl" color="blue" radius="xl">
+        <Avatar
+          src={resolveAvatarUrl(user.avatarUrl)}
+          size="xl"
+          color="blue"
+          radius="xl"
+        >
           {user.name.charAt(0).toUpperCase()}
         </Avatar>
         <Text size="xl" fw={700} ta="center">

--- a/frontend/components/Mobile/UserSelector.tsx
+++ b/frontend/components/Mobile/UserSelector.tsx
@@ -8,6 +8,7 @@ import {
   Group,
   UnstyledButton,
 } from "@mantine/core";
+import { resolveAvatarUrl } from "../../lib/resolveAvatarUrl";
 
 interface UserSelectorProps {
   users: Person[];
@@ -28,7 +29,12 @@ const UserSelector: React.FC<UserSelectorProps> = ({ users, onSelectUser }) => {
         >
           <Card shadow="sm" padding="lg" radius="md" withBorder>
             <Group>
-              <Avatar color="blue" radius="xl" size="lg">
+              <Avatar
+                src={resolveAvatarUrl(user.avatarUrl)}
+                color="blue"
+                radius="xl"
+                size="lg"
+              >
                 {user.name.charAt(0).toUpperCase()}
               </Avatar>
               <Text fz="lg" fw={500}>


### PR DESCRIPTION
## Summary
- resolve avatars in mobile quick actions
- show avatars in mobile user selector

## Testing
- `npm test` *(fails: `next` not found)*
- `pytest -q` *(fails: missing `httpx`)*

------
https://chatgpt.com/codex/tasks/task_b_6842ed58d5e4832694684ae46c26179c