### PR TITLE
Display nicknames in mobile views

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -17,9 +17,16 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
         <Avatar size="xl" color="blue" radius="xl">
           {user.name.charAt(0).toUpperCase()}
         </Avatar>
-        <Text size="xl" fw={700} ta="center">
-          {user.name}
-        </Text>
+        <Stack gap={2} align="center">
+          <Text size="xl" fw={700} ta="center">
+            {user.name}
+          </Text>
+          {user.nickname && (
+            <Text size="sm" c="dimmed" ta="center">
+              “{user.nickname}”
+            </Text>
+          )}
+        </Stack>
         <Box>
           <Text size="lg" c="dimmed" ta="center">
             Current Balance

--- a/frontend/components/Mobile/UserSelector.tsx
+++ b/frontend/components/Mobile/UserSelector.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   Avatar,
   Group,
+  Stack,
   UnstyledButton,
 } from "@mantine/core";
 
@@ -31,9 +32,16 @@ const UserSelector: React.FC<UserSelectorProps> = ({ users, onSelectUser }) => {
               <Avatar color="blue" radius="xl" size="lg">
                 {user.name.charAt(0).toUpperCase()}
               </Avatar>
-              <Text fz="lg" fw={500}>
-                {user.name}
-              </Text>
+              <Stack gap={2}>
+                <Text fz="lg" fw={500}>
+                  {user.name}
+                </Text>
+                {user.nickname && (
+                  <Text c="dimmed" size="sm">
+                    “{user.nickname}”
+                  </Text>
+                )}
+              </Stack>
             </Group>
           </Card>
         </UnstyledButton>


### PR DESCRIPTION
## Summary
- show nickname below user name in mobile quick actions card
- show nickname in mobile user list

## Testing
- `PYTHONPATH=. pytest -q` *(fails: DetachedInstanceError: Instance <Person> is not bound to a Session)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6842eebf366c83269ab70427d773df22