### PR TITLE
Allow avatar change on mobile actions page

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -1,28 +1,55 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Person } from "../../types";
-import { Paper, Group, Avatar, Text, Stack, Box } from "@mantine/core";
+import { Paper, Avatar, Text, Stack, Box, Button } from "@mantine/core";
 import { resolveAvatarUrl } from "../../lib/resolveAvatarUrl";
+import classes from "../UserCard/UserCardImage.module.css";
 // Removed ThemeIcon and IconCash as they are not used in the final example from the prompt
 // but good to keep in mind for future enhancements.
 
 interface UserQuickActionsDisplayProps {
   user: Person;
+  onChangeAvatar?: (file: File | null) => void;
 }
 
 const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
   user,
+  onChangeAvatar,
 }) => {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const triggerFile = () => fileRef.current?.click();
   return (
     <Paper shadow="md" p="lg" radius="md" withBorder>
       <Stack align="center" gap="md">
-        <Avatar
-          src={resolveAvatarUrl(user.avatarUrl)}
-          size="xl"
-          color="blue"
-          radius="xl"
-        >
-          {user.name.charAt(0).toUpperCase()}
-        </Avatar>
+        <div style={{ position: "relative" }}>
+          <Avatar
+            src={resolveAvatarUrl(user.avatarUrl)}
+            size="xl"
+            color="blue"
+            radius="xl"
+          >
+            {user.name.charAt(0).toUpperCase()}
+          </Avatar>
+          {onChangeAvatar && (
+            <>
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/*"
+                style={{ display: "none" }}
+                onChange={(e) =>
+                  onChangeAvatar(e.currentTarget.files?.[0] ?? null)
+                }
+              />
+              <Button
+                size="xs"
+                className={classes.changeBtn}
+                onClick={triggerFile}
+              >
+                <span>📷</span>
+              </Button>
+            </>
+          )}
+        </div>
         <Text size="xl" fw={700} ta="center">
           {user.name}
         </Text>

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import Cookies from "js-cookie";
 import {
@@ -88,6 +88,23 @@ const MobileQuickActionsPage: React.FC = () => {
     }
   };
 
+  const handleAvatarChange = async (file: File | null) => {
+    if (!file || !user) return;
+    setActionLoading((prev) => ({ ...prev, drink: true }));
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      await api.post(`/users/${user.id}/avatar`, form, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      await fetchUserData(user.id.toString());
+    } catch {
+      setError("Failed to update avatar. Please try again.");
+    } finally {
+      setActionLoading((prev) => ({ ...prev, drink: false }));
+    }
+  };
+
   if (loading && !user) {
     // Show loader only if truly loading initial data
     return (
@@ -173,7 +190,10 @@ const MobileQuickActionsPage: React.FC = () => {
 
       <Box mb="xl">
         {" "}
-        <UserQuickActionsDisplay user={user} />
+        <UserQuickActionsDisplay
+          user={user}
+          onChangeAvatar={handleAvatarChange}
+        />
       </Box>
 
       <Stack>


### PR DESCRIPTION
## Summary
- add an optional avatar upload control to `UserQuickActionsDisplay`
- support avatar change on `MobileQuickActions` page

## Testing
- `npm test --prefix frontend` *(fails: `next` not found)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6842ef9aeb98832691468590019c72d4