### PR TITLE
Adjust user creation policy

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,7 +59,6 @@ def read_users(db: Session = Depends(get_db)):
 def create_user(
     person: schemas.PersonCreate,
     db: Session = Depends(get_db),
-    admin: None = Depends(get_current_admin),
 ):
     return crud.create_person(db, person)
 

--- a/frontend/pages/AddUserPage.tsx
+++ b/frontend/pages/AddUserPage.tsx
@@ -11,7 +11,6 @@ import {
 } from "@mantine/core";
 import { IconPlus, IconTrash, IconCheck, IconX } from "@tabler/icons-react";
 import api from "../api/api";
-import { AdminGate } from "../components/Admin/AdminGate";
 
 interface UserNotification {
   id: number;
@@ -59,77 +58,75 @@ export default function AddUserPage() {
     setNames((prev) => prev.map((n, i) => (i === idx ? value : n)));
 
   return (
-    <AdminGate>
-      <Paper shadow="sm" p="lg" maw={400} mx="auto">
-        <Title order={3} mb="md">
-          Add New Users
-        </Title>
+    <Paper shadow="sm" p="lg" maw={400} mx="auto">
+      <Title order={3} mb="md">
+        Add New Users
+      </Title>
 
-        <form onSubmit={handleSubmit}>
-          <Stack>
-            {names.map((n, idx) => (
-              <Group key={idx} align="flex-end">
-                <TextInput
-                  label="Name"
-                  placeholder="Enter user name"
-                  required
-                  flex={1}
-                  value={n}
-                  onChange={(e) => changeField(idx, e.currentTarget.value)}
-                />
-                {names.length > 1 && (
-                  <ActionIcon
-                    color="red"
-                    variant="subtle"
-                    mt="sm"
-                    onClick={() => removeField(idx)}
-                    aria-label="Remove"
-                  >
-                    <IconTrash size={16} />
-                  </ActionIcon>
-                )}
-              </Group>
-            ))}
-
-            <Button
-              variant="light"
-              leftSection={<IconPlus size={16} />}
-              onClick={addField}
-            >
-              Add Another
-            </Button>
-
-            <Group justify="flex-end">
-              <Button type="submit">Create Users</Button>
-            </Group>
-          </Stack>
-        </form>
-
-        <Stack pos="fixed" bottom={16} right={16} gap="sm">
-          {notifications.map((n) => (
-            <Notification
-              key={n.id}
-              withCloseButton
-              onClose={() =>
-                setNotifications((prev) => prev.filter((nn) => nn.id !== n.id))
-              }
-              color={n.success ? "teal" : "red"}
-              icon={n.success ? <IconCheck size={16} /> : <IconX size={16} />}
-              title={n.success ? "User added" : "Error"}
-            >
-              {n.success ? (
-                <>
-                  Added <strong>{n.name}</strong>
-                </>
-              ) : (
-                <>
-                  Failed to add <strong>{n.name}</strong>: {n.message}
-                </>
+      <form onSubmit={handleSubmit}>
+        <Stack>
+          {names.map((n, idx) => (
+            <Group key={idx} align="flex-end">
+              <TextInput
+                label="Name"
+                placeholder="Enter user name"
+                required
+                flex={1}
+                value={n}
+                onChange={(e) => changeField(idx, e.currentTarget.value)}
+              />
+              {names.length > 1 && (
+                <ActionIcon
+                  color="red"
+                  variant="subtle"
+                  mt="sm"
+                  onClick={() => removeField(idx)}
+                  aria-label="Remove"
+                >
+                  <IconTrash size={16} />
+                </ActionIcon>
               )}
-            </Notification>
+            </Group>
           ))}
+
+          <Button
+            variant="light"
+            leftSection={<IconPlus size={16} />}
+            onClick={addField}
+          >
+            Add Another
+          </Button>
+
+          <Group justify="flex-end">
+            <Button type="submit">Create Users</Button>
+          </Group>
         </Stack>
-      </Paper>
-    </AdminGate>
+      </form>
+
+      <Stack pos="fixed" bottom={16} right={16} gap="sm">
+        {notifications.map((n) => (
+          <Notification
+            key={n.id}
+            withCloseButton
+            onClose={() =>
+              setNotifications((prev) => prev.filter((nn) => nn.id !== n.id))
+            }
+            color={n.success ? "teal" : "red"}
+            icon={n.success ? <IconCheck size={16} /> : <IconX size={16} />}
+            title={n.success ? "User added" : "Error"}
+          >
+            {n.success ? (
+              <>
+                Added <strong>{n.name}</strong>
+              </>
+            ) : (
+              <>
+                Failed to add <strong>{n.name}</strong>: {n.message}
+              </>
+            )}
+          </Notification>
+        ))}
+      </Stack>
+    </Paper>
   );
 }

--- a/frontend/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/pages/__tests__/AddUserPage.test.tsx
@@ -12,18 +12,9 @@ afterEach(() => {
 });
 
 test("adds multiple users", async () => {
-  mock.onPost("/auth/login").reply(200, { access_token: "tok" });
   mock.onPost("/users").reply(201);
 
   render(<AddUserPage />);
-
-  await userEvent.type(
-    screen.getByPlaceholderText(/enter admin password/i),
-    "pass",
-  );
-  await userEvent.click(screen.getByRole("button", { name: /login/i }));
-
-  await waitFor(() => expect(localStorage.getItem("admin_token")).toBe("tok"));
 
   await userEvent.click(screen.getByRole("button", { name: /add another/i }));
   const inputs = screen.getAllByLabelText(/name/i);


### PR DESCRIPTION
## Summary
- allow creating users without admin auth
- show AddUser page to all users
- update AddUserPage tests accordingly

## Testing
- `npm test` *(fails: code style issues)*
- `pytest -q` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_b_6842ee0d18e08326ae5094b7593ecaca