### PR TITLE
Add search bar on mobile user select

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -39,15 +39,22 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
                   onChangeAvatar(e.currentTarget.files?.[0] ?? null)
                 }
               />
-                <Button
+              <Button
                 size="xs"
                 className={classes.changeBtn}
                 onClick={triggerFile}
-                style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: 0, width: 36, height: 36 }}
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  padding: 0,
+                  width: 36,
+                  height: 36,
+                }}
                 variant="subtle"
-                >
+              >
                 <IconCamera size={26} />
-                </Button>
+              </Button>
             </>
           )}
         </div>

--- a/frontend/components/UserCard/UserCard.tsx
+++ b/frontend/components/UserCard/UserCard.tsx
@@ -8,7 +8,7 @@ import {
   Stack,
   Group,
 } from "@mantine/core";
-import { IconCoffee, IconCreditCardPay } from '@tabler/icons-react';
+import { IconCoffee, IconCreditCardPay } from "@tabler/icons-react";
 import classes from "./UserCardImage.module.css";
 import { Person } from "../../types";
 import { resolveAvatarUrl } from "../../lib/resolveAvatarUrl";
@@ -43,7 +43,7 @@ export function UserCardImage({
       {/* Avatar */}
       <div className={classes.avatarWrapper}>
         <Avatar
-          src={resolveAvatarUrl(user.avatarUrl)} 
+          src={resolveAvatarUrl(user.avatarUrl)}
           size={80}
           radius={80}
           mx="auto"
@@ -90,10 +90,19 @@ export function UserCardImage({
 
       {/* Actions: +1 Drink, Top Up */}
       <Stack gap={8} mt="md">
-        <Button fullWidth leftSection={<IconCoffee size={25} />} onClick={onDrink}>
+        <Button
+          fullWidth
+          leftSection={<IconCoffee size={25} />}
+          onClick={onDrink}
+        >
           +1 Drink
         </Button>
-        <Button fullWidth leftSection={<IconCreditCardPay size={25} />}  variant="outline" onClick={onTopUp}>
+        <Button
+          fullWidth
+          leftSection={<IconCreditCardPay size={25} />}
+          variant="outline"
+          onClick={onTopUp}
+        >
           Top Up
         </Button>
       </Stack>

--- a/frontend/lib/resolveAvatarUrl.ts
+++ b/frontend/lib/resolveAvatarUrl.ts
@@ -4,7 +4,7 @@ export function resolveAvatarUrl(avatarUrl?: string): string | undefined {
 
   if (!avatarUrl) {
     console.log(
-      "[resolveAvatarUrl] avatarUrl is undefined or empty → returning undefined"
+      "[resolveAvatarUrl] avatarUrl is undefined or empty → returning undefined",
     );
     return undefined;
   }
@@ -16,7 +16,7 @@ export function resolveAvatarUrl(avatarUrl?: string): string | undefined {
   } catch (err) {
     console.log(
       "[resolveAvatarUrl] URL constructor threw, falling back to raw avatarUrl →",
-      avatarUrl
+      avatarUrl,
     );
     return avatarUrl;
   }

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mantine/core"; // Removed Paper, Group as they are now encapsulated in UserQuickActionsDisplay
 import api from "../api/api";
 import { Person } from "../types";
-import { IconCoffee, IconCreditCardPay, IconUser } from '@tabler/icons-react';
+import { IconCoffee, IconCreditCardPay, IconUser } from "@tabler/icons-react";
 import UserQuickActionsDisplay from "../components/Mobile/UserQuickActionsDisplay";
 import MobileTopUpModal from "../components/Mobile/MobileTopUpModal";
 

--- a/frontend/pages/MobileUserSelect.tsx
+++ b/frontend/pages/MobileUserSelect.tsx
@@ -1,7 +1,15 @@
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 import Cookies from "js-cookie";
-import { Container, Title, Loader, Button, Text } from "@mantine/core"; // Removed Stack as UserSelector will handle layout
+import {
+  Container,
+  Title,
+  Loader,
+  Button,
+  Text,
+  TextInput,
+} from "@mantine/core"; // Removed Stack as UserSelector will handle layout
+import { IconSearch } from "@tabler/icons-react";
 import api from "../api/api";
 import { Person } from "../types";
 import UserSelector from "../components/Mobile/UserSelector";
@@ -10,6 +18,7 @@ const MobileUserSelectPage: React.FC = () => {
   const [users, setUsers] = useState<Person[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
   const router = useRouter();
 
   useEffect(() => {
@@ -32,6 +41,13 @@ const MobileUserSelectPage: React.FC = () => {
     Cookies.set("selected_user_id", userId.toString(), { expires: 7 }); // Ensure userId is string
     router.push("/MobileQuickActions");
   };
+
+  const searchLower = search.toLowerCase();
+  const filteredUsers = users.filter(
+    (u) =>
+      u.name.toLowerCase().includes(searchLower) ||
+      (u.nickname ?? "").toLowerCase().includes(searchLower),
+  );
 
   if (loading) {
     return (
@@ -75,8 +91,15 @@ const MobileUserSelectPage: React.FC = () => {
       <Title order={1} ta="center" mb="xl">
         Select User
       </Title>
-      <UserSelector users={users} onSelectUser={handleSelectUser} />
-      {users.length === 0 && !loading && (
+      <TextInput
+        placeholder="Search users..."
+        leftSection={<IconSearch size={16} />}
+        mb="md"
+        value={search}
+        onChange={(e) => setSearch(e.currentTarget.value)}
+      />
+      <UserSelector users={filteredUsers} onSelectUser={handleSelectUser} />
+      {filteredUsers.length === 0 && !loading && (
         <Text ta="center" mt="lg">
           No users found.
         </Text>

--- a/frontend/pages/__tests__/MobileUserSelect.test.tsx
+++ b/frontend/pages/__tests__/MobileUserSelect.test.tsx
@@ -1,0 +1,34 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent } from "../../test-utils";
+import MobileUserSelectPage from "../MobileUserSelect";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  mock.restore();
+});
+
+test("filters users by name and nickname", async () => {
+  mock.onGet("/users").reply(200, [
+    { id: 1, name: "Alice", nickname: "Al", balance: 5, total_drinks: 0 },
+    { id: 2, name: "Bob", balance: 5, total_drinks: 0 },
+  ]);
+
+  render(<MobileUserSelectPage />);
+
+  // Wait for users to load
+  await screen.findByText(/Alice/);
+
+  const input = screen.getByPlaceholderText(/search users/i);
+  await userEvent.clear(input);
+  await userEvent.type(input, "al");
+  expect(screen.getByText(/Alice/)).toBeInTheDocument();
+  expect(screen.queryByText(/Bob/)).not.toBeInTheDocument();
+
+  await userEvent.clear(input);
+  await userEvent.type(input, "bob");
+  expect(screen.getByText(/Bob/)).toBeInTheDocument();
+  expect(screen.queryByText(/Alice/)).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add search bar and filtering on MobileUserSelect page
- create tests to cover search on mobile user select
- format codebase with Prettier for consistency

## Testing
- `npm --prefix frontend test` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f56a332483268878a9d6a6c4ef6d