### PR TITLE
Delete old avatar on update

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -101,6 +101,14 @@ async def upload_avatar(
     user = crud.get_person(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Remove previous avatar file if it exists
+    old_avatar = user.avatar_url
+    if old_avatar and old_avatar.startswith("/avatars/"):
+        old_path = os.path.join(avatars_dir, os.path.basename(old_avatar))
+        if os.path.exists(old_path):
+            os.remove(old_path)
+
     ext = os.path.splitext(file.filename)[1]
     filename = f"{user_id}_{uuid4().hex}{ext}"
     filepath = os.path.join(avatars_dir, filename)

--- a/backend/tests/test_avatar_deletion.py
+++ b/backend/tests/test_avatar_deletion.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Provide dummy env vars
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ["TESTING"] = "1"
+
+from app.main import app, get_db
+from app.models import Base, Person
+from app.routers import users as users_router
+
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+client = TestClient(app)
+
+
+def clear_avatars():
+    for f in os.listdir(users_router.avatars_dir):
+        os.remove(os.path.join(users_router.avatars_dir, f))
+
+
+def test_avatar_update_deletes_old_file():
+    app.dependency_overrides[get_db] = override_get_db
+    clear_avatars()
+    with TestingSessionLocal() as db:
+        user = Person(name="Test")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        user_id = user.id
+
+    # first upload
+    resp = client.post(
+        f"/users/{user_id}/avatar",
+        files={"file": ("a1.png", b"first", "image/png")},
+    )
+    assert resp.status_code == 200
+    first_url = resp.json()["avatar_url"]
+    first_path = os.path.join(users_router.avatars_dir, os.path.basename(first_url))
+    assert os.path.exists(first_path)
+
+    # second upload
+    resp = client.post(
+        f"/users/{user_id}/avatar",
+        files={"file": ("a2.png", b"second", "image/png")},
+    )
+    assert resp.status_code == 200
+    second_url = resp.json()["avatar_url"]
+    second_path = os.path.join(users_router.avatars_dir, os.path.basename(second_url))
+    assert os.path.exists(second_path)
+    assert not os.path.exists(first_path)
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- delete the user's old avatar file when uploading a new one
- add regression test for deleting old avatars

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842f5d47710832692cef6480f1a5429