### PR TITLE
Add drink button animation

### DIFF
--- a/frontend/components/UserCard/UserCard.tsx
+++ b/frontend/components/UserCard/UserCard.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import {
   Avatar,
   Button,
@@ -27,6 +27,13 @@ export function UserCardImage({
   onChangeAvatar,
 }: UserCardProps) {
   const fileRef = useRef<HTMLInputElement>(null);
+  const [animateDrink, setAnimateDrink] = useState(false);
+
+  const handleDrink = () => {
+    onDrink();
+    setAnimateDrink(true);
+    setTimeout(() => setAnimateDrink(false), 300);
+  };
 
   return (
     <Card withBorder radius="md" className={classes.card}>
@@ -93,7 +100,8 @@ export function UserCardImage({
         <Button
           fullWidth
           leftSection={<IconCoffee size={25} />}
-          onClick={onDrink}
+          onClick={handleDrink}
+          className={`${classes.drinkButton} ${animateDrink ? classes.animate : ""}`}
         >
           +1 Drink
         </Button>

--- a/frontend/components/UserCard/UserCardImage.module.css
+++ b/frontend/components/UserCard/UserCardImage.module.css
@@ -28,3 +28,23 @@
   border-radius: 50%;
   padding: 4px;
 }
+
+.drinkButton {
+  transition: transform 0.2s ease;
+}
+
+.animate {
+  animation: drinkBounce 0.3s ease;
+}
+
+@keyframes drinkBounce {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Summary
- add a small bounce animation for the "+1 Drink" button

## Testing
- `npm test --silent` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f97322a083269df8f79f90d24050