### PR TITLE
Change positive balance color to blue

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -70,7 +70,7 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
             size="xxl"
             fw={700}
             ta="center"
-            c={user.balance > 0 ? "teal" : user.balance < 0 ? "red" : "dimmed"}
+            c={user.balance > 0 ? "blue" : user.balance < 0 ? "red" : "dimmed"}
           >
             €{user.balance.toFixed(2)}
           </Text>

--- a/frontend/components/UserCard/UserCard.tsx
+++ b/frontend/components/UserCard/UserCard.tsx
@@ -78,7 +78,17 @@ export function UserCardImage({
 
       {/* Single Stat: Balance */}
       <Group justify="center" gap={4} mb="md">
-        <Text size="lg" fw={500}>
+        <Text
+          size="lg"
+          fw={500}
+          c={
+            Number(user.balance ?? 0) > 0
+              ? "blue"
+              : Number(user.balance ?? 0) < 0
+                ? "red"
+                : "dimmed"
+          }
+        >
           €{Number(user.balance ?? 0).toFixed(2)}
         </Text>
         <Text color="dimmed" size="sm">


### PR DESCRIPTION
## Summary
- update mobile balance styling to show blue when positive
- update UserCard balance styling to show blue when positive

## Testing
- `npm install` *(fails: dependency conflicts)*
- `npm run test` *(fails: next not found)*
- `pytest` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_6842fa406a5c8326a955fb1979d59868