### PR TITLE
Center and style mobile top-up modal

### DIFF
--- a/frontend/components/Mobile/MobileTopUpModal.tsx
+++ b/frontend/components/Mobile/MobileTopUpModal.tsx
@@ -41,12 +41,13 @@ const MobileTopUpModal: React.FC<MobileTopUpModalProps> = ({
     radius="md"
     padding="lg"
   >
-    <Stack gap="md">
+    <Stack gap="md" align="center">
       <Text ta="center" c="dimmed" mb={4}>
         Choose a preset amount or enter a custom value.
       </Text>
       <SegmentedControl
         fullWidth
+        w="100%"
         data={presetAmounts.map((v) => ({ label: `€${v}`, value: v }))}
         value={amount.toString()}
         onChange={(value) => onChangeAmount(Number(value))}
@@ -58,10 +59,13 @@ const MobileTopUpModal: React.FC<MobileTopUpModalProps> = ({
         value={amount}
         onChange={(val) => typeof val === "number" && onChangeAmount(val)}
         hideControls
-        styles={{ input: { textAlign: "center", fontSize: 20 } }}
+        styles={{
+          input: { textAlign: "center", fontSize: 20 },
+          label: { width: "100%", textAlign: "center" },
+        }}
       />
-      <Group justify="space-between" mt="md">
-        <Button variant="outline" color="gray" onClick={onClose}>
+      <Group justify="center" mt="md" gap="sm" w="100%">
+        <Button variant="light" color="gray" onClick={onClose}>
           Cancel
         </Button>
         <Button color="teal" onClick={onConfirm}>


### PR DESCRIPTION
## Summary
- center content in `MobileTopUpModal`
- align input labels and buttons
- use same colors for cancel/confirm buttons as desktop

## Testing
- `npm run test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842f9f3752c83269917c670034063ed