### PR TITLE
Add drink notification to mobile page

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -42,6 +42,29 @@ def record_drink(db: Session, person_id: int):
     return person
 
 
+def undo_last_drink(db: Session, person_id: int):
+    """Revert the most recent drink event for a user."""
+    person = get_person(db, person_id)
+    if not person or person.total_drinks <= 0:
+        return None
+
+    last_event = (
+        db.query(models.DrinkEvent)
+        .filter(models.DrinkEvent.person_id == person_id)
+        .order_by(models.DrinkEvent.id.desc())
+        .first()
+    )
+    if not last_event:
+        return None
+
+    person.balance += Decimal("1.00")
+    person.total_drinks -= 1
+    db.delete(last_event)
+    db.commit()
+    db.refresh(person)
+    return person
+
+
 # crud.py
 def update_user_balance(
     db: Session, user_id: int, new_balance: float, new_total_drinks: int | None = None

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -66,6 +66,14 @@ def add_drink(user_id: int, db: Session = Depends(get_db)):
     return person
 
 
+@router.post("/users/{user_id}/drinks/undo", response_model=schemas.Person)
+def undo_drink(user_id: int, db: Session = Depends(get_db)):
+    person = crud.undo_last_drink(db, user_id)
+    if not person:
+        raise HTTPException(status_code=404, detail="User or drink not found")
+    return person
+
+
 @router.patch("/users/{user_id}")
 def update_user(
     user_id: int,

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -9,12 +9,23 @@ import {
   Box,
   Text,
   Stack,
+  Notification,
 } from "@mantine/core"; // Removed Paper, Group as they are now encapsulated in UserQuickActionsDisplay
 import api from "../api/api";
 import { Person } from "../types";
-import { IconCoffee, IconCreditCardPay, IconUser } from "@tabler/icons-react";
+import {
+  IconCoffee,
+  IconCreditCardPay,
+  IconUser,
+  IconX,
+} from "@tabler/icons-react";
 import UserQuickActionsDisplay from "../components/Mobile/UserQuickActionsDisplay";
 import MobileTopUpModal from "../components/Mobile/MobileTopUpModal";
+
+interface DrinkNotification {
+  user: Person;
+  id: number;
+}
 
 const MobileQuickActionsPage: React.FC = () => {
   const [user, setUser] = useState<Person | null>(null);
@@ -26,6 +37,7 @@ const MobileQuickActionsPage: React.FC = () => {
   });
   const [topUpModalOpen, setTopUpModalOpen] = useState(false);
   const [topUpAmount, setTopUpAmount] = useState(5);
+  const [notifications, setNotifications] = useState<DrinkNotification[]>([]);
   const router = useRouter();
 
   const fetchUserData = useCallback(async (userId: string) => {
@@ -61,6 +73,14 @@ const MobileQuickActionsPage: React.FC = () => {
     }
     setActionLoading((prev) => ({ ...prev, drink: true }));
     try {
+      const freshUser = (await api.get<Person>(`/users/${user.id}`)).data;
+      setNotifications((prev) => [
+        ...prev,
+        {
+          id: Date.now(),
+          user: freshUser,
+        },
+      ]);
       await api.post(`/users/${user.id}/drinks`);
       await fetchUserData(user.id.toString());
     } catch (err) {
@@ -68,6 +88,18 @@ const MobileQuickActionsPage: React.FC = () => {
     } finally {
       setActionLoading((prev) => ({ ...prev, drink: false }));
     }
+  };
+
+  const handleUndoDrink = async (notif: DrinkNotification) => {
+    const freshUser = (await api.get<Person>(`/users/${notif.user.id}`)).data;
+
+    await api.patch(`/users/${notif.user.id}`, {
+      balance: freshUser.balance + 1,
+      total_drinks: freshUser.total_drinks - 1,
+    });
+
+    await fetchUserData(notif.user.id.toString());
+    setNotifications((prev) => prev.filter((n) => n.id !== notif.id));
   };
 
   const handleTopUp = async () => {
@@ -233,6 +265,31 @@ const MobileQuickActionsPage: React.FC = () => {
         onConfirm={handleTopUp}
         onClose={() => setTopUpModalOpen(false)}
       />
+
+      <Stack pos="fixed" bottom={16} right={16} gap="sm">
+        {notifications.map((notif) => (
+          <Notification
+            key={notif.id}
+            onClose={() =>
+              setNotifications((prev) => prev.filter((n) => n.id !== notif.id))
+            }
+            withCloseButton
+            icon={<IconX size={16} />}
+            color="teal"
+            title="Drink added"
+          >
+            +1 drink added to <strong>{notif.user.name}</strong>
+            <Button
+              size="xs"
+              ml="sm"
+              variant="light"
+              onClick={() => handleUndoDrink(notif)}
+            >
+              Undo
+            </Button>
+          </Notification>
+        ))}
+      </Stack>
     </Container>
   );
 };

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -91,13 +91,7 @@ const MobileQuickActionsPage: React.FC = () => {
   };
 
   const handleUndoDrink = async (notif: DrinkNotification) => {
-    const freshUser = (await api.get<Person>(`/users/${notif.user.id}`)).data;
-
-    await api.patch(`/users/${notif.user.id}`, {
-      balance: freshUser.balance + 1,
-      total_drinks: freshUser.total_drinks - 1,
-    });
-
+    await api.post(`/users/${notif.user.id}/drinks/undo`);
     await fetchUserData(notif.user.id.toString());
     setNotifications((prev) => prev.filter((n) => n.id !== notif.id));
   };

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -93,13 +93,7 @@ export default function HomePage() {
   };
 
   const handleUndoDrink = async (notif: DrinkNotification) => {
-    const freshUser = (await api.get<Person>(`/users/${notif.user.id}`)).data;
-
-    await api.patch(`/users/${notif.user.id}`, {
-      balance: freshUser.balance + 1,
-      total_drinks: freshUser.total_drinks - 1,
-    });
-
+    await api.post(`/users/${notif.user.id}/drinks/undo`);
     await fetchUsers();
     setNotifications((prev) => prev.filter((n) => n.id !== notif.id));
   };


### PR DESCRIPTION
## Summary
- show notifications on the mobile quick actions page
- allow undoing a drink entry just like the desktop page

## Testing
- `npm test` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842fb7d5b4483268402d5b460176aee