### PR TITLE
Improve mobile quick actions layout

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -17,7 +17,11 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
   const fileRef = useRef<HTMLInputElement>(null);
   const triggerFile = () => fileRef.current?.click();
   return (
-    <Card withBorder radius="md" className={classes.card}>
+    <Card
+      withBorder
+      radius="md"
+      className={`${classes.card} ${classes.fullWidth}`}
+    >
       {/* Header Image */}
       <Card.Section
         h={120}

--- a/frontend/components/UserCard/UserCardImage.module.css
+++ b/frontend/components/UserCard/UserCardImage.module.css
@@ -48,3 +48,8 @@
     transform: scale(1);
   }
 }
+
+.fullWidth {
+  width: 100%;
+}
+

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Stack,
 } from "@mantine/core"; // Removed Paper, Group as they are now encapsulated in UserQuickActionsDisplay
+import classes from "../styles/MobileQuickActions.module.css";
 import api from "../api/api";
 import { Person } from "../types";
 import { IconCoffee, IconCreditCardPay, IconUser } from "@tabler/icons-react";
@@ -180,7 +181,7 @@ const MobileQuickActionsPage: React.FC = () => {
   }
 
   return (
-    <Container py="xl">
+    <Box className={classes.page}>
       <Box mb="xl">
         {" "}
         <UserQuickActionsDisplay
@@ -229,7 +230,7 @@ const MobileQuickActionsPage: React.FC = () => {
         onConfirm={handleTopUp}
         onClose={() => setTopUpModalOpen(false)}
       />
-    </Container>
+    </Box>
   );
 };
 

--- a/frontend/styles/MobileQuickActions.module.css
+++ b/frontend/styles/MobileQuickActions.module.css
@@ -1,0 +1,7 @@
+.page {
+  width: 100%;
+  min-height: 100vh;
+  padding: var(--mantine-spacing-lg);
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
## Summary
- create MobileQuickActions.module.css for full-bleed layout
- adjust page to use full-width Box container
- ensure quick actions card spans full width
- add `.fullWidth` rule to card styles

## Testing
- `npm run test` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842fcbdcea48326b18874e1814a7465