### PR TITLE
Fix mobile quick actions layout

### DIFF
--- a/frontend/components/Mobile/UserQuickActionsDisplay.tsx
+++ b/frontend/components/Mobile/UserQuickActionsDisplay.tsx
@@ -17,66 +17,66 @@ const UserQuickActionsDisplay: React.FC<UserQuickActionsDisplayProps> = ({
   const fileRef = useRef<HTMLInputElement>(null);
   const triggerFile = () => fileRef.current?.click();
   return (
-      <Stack align="center" gap="md" px="lg" pb="lg">
-        <div className={classes.avatarWrapper}>
-          <Avatar
-            src={resolveAvatarUrl(user.avatarUrl)}
-            size={200}
-            radius={200}
-            mx="auto"
-            mt={-40}
-            className={classes.avatar}
-          >
-            {user.name.charAt(0).toUpperCase()}
-          </Avatar>
-          {onChangeAvatar && (
-            <>
-              <input
-                ref={fileRef}
-                type="file"
-                accept="image/*"
-                style={{ display: "none" }}
-                onChange={(e) =>
-                  onChangeAvatar(e.currentTarget.files?.[0] ?? null)
-                }
-              />
-              <Button
-                size="xs"
-                className={classes.changeBtn}
-                onClick={triggerFile}
-                style={{
-                  display: "flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  padding: 0,
-                  width: 36,
-                  height: 36,
-                }}
-                variant="subtle"
-              >
-                <IconCamera size={26} />
-              </Button>
-            </>
-          )}
-        </div>
-        <Text size="xl" fw={700} ta="center">
-          {user.name}
+    <Stack align="center" gap="md" px="lg" pb="lg">
+      <div className={classes.avatarWrapper}>
+        <Avatar
+          src={resolveAvatarUrl(user.avatarUrl)}
+          size={200}
+          radius={200}
+          mx="auto"
+          mt={-40}
+          className={classes.avatar}
+        >
+          {user.name.charAt(0).toUpperCase()}
+        </Avatar>
+        {onChangeAvatar && (
+          <>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={(e) =>
+                onChangeAvatar(e.currentTarget.files?.[0] ?? null)
+              }
+            />
+            <Button
+              size="xs"
+              className={classes.changeBtn}
+              onClick={triggerFile}
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                padding: 0,
+                width: 36,
+                height: 36,
+              }}
+              variant="subtle"
+            >
+              <IconCamera size={26} />
+            </Button>
+          </>
+        )}
+      </div>
+      <Text size="xl" fw={700} ta="center">
+        {user.name}
+      </Text>
+      <Box>
+        <Text size="lg" c="dimmed" ta="center">
+          Current Balance
         </Text>
-        <Box>
-          <Text size="lg" c="dimmed" ta="center">
-            Current Balance
-          </Text>
-          {/* Conditional coloring for balance */}
-          <Text
-            size="xxl"
-            fw={700}
-            ta="center"
-            c={user.balance > 0 ? "blue" : user.balance < 0 ? "red" : "dimmed"}
-          >
-            €{user.balance.toFixed(2)}
-          </Text>
-        </Box>
-      </Stack>    
+        {/* Conditional coloring for balance */}
+        <Text
+          size="xxl"
+          fw={700}
+          ta="center"
+          c={user.balance > 0 ? "blue" : user.balance < 0 ? "red" : "dimmed"}
+        >
+          €{user.balance.toFixed(2)}
+        </Text>
+      </Box>
+    </Stack>
   );
 };
 

--- a/frontend/pages/MobileQuickActions.tsx
+++ b/frontend/pages/MobileQuickActions.tsx
@@ -136,7 +136,7 @@ const MobileQuickActionsPage: React.FC = () => {
   if (loading && !user) {
     // Show loader only if truly loading initial data
     return (
-      <Container className={styles.container}>     
+      <Container className={styles.container} fluid>
         <Loader />
       </Container>
     );
@@ -144,7 +144,7 @@ const MobileQuickActionsPage: React.FC = () => {
 
   if (error) {
     return (
-      <Container className={styles.container}>     
+      <Container className={styles.container} fluid>
         <Title order={2} c="red.500" ta="center">
           Error
         </Title>
@@ -173,7 +173,7 @@ const MobileQuickActionsPage: React.FC = () => {
   if (!user) {
     // Should ideally be covered by loading or error state, but as a fallback
     return (
-      <Container className={styles.container}>     
+      <Container className={styles.container} fluid>
         <Text>No user data available. You might need to re-select a user.</Text>
         <Button onClick={() => router.push("/MobileUserSelect")} mt="md">
           Go to User Selection
@@ -183,7 +183,7 @@ const MobileQuickActionsPage: React.FC = () => {
   }
 
   return (
-    <Container className={styles.container}>
+    <Container className={styles.container} fluid>
       <Box className={styles.box}>
         <UserQuickActionsDisplay
           user={user}
@@ -191,7 +191,7 @@ const MobileQuickActionsPage: React.FC = () => {
         />
       </Box>
 
-      <Stack className={styles.stack}> 
+      <Stack className={styles.stack}>
         <Button
           onClick={handleAddDrink}
           loading={actionLoading.drink}

--- a/frontend/styles/MobileQuickActions.module.css
+++ b/frontend/styles/MobileQuickActions.module.css
@@ -1,44 +1,45 @@
 .container {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height:40rem;
-    width: 90%;
-    padding: 20px;
-    background: transparent; /* Remove background-color here */
-    overflow: hidden;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+  background: transparent; /* Remove background-color here */
+  overflow: hidden;
 }
 
 .container::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image: url("/images/Logo.png");
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    opacity: 0.1; /* 50% transparency */
-    z-index: 0;
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url("/images/Logo.png");
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: 0.1; /* 50% transparency */
+  z-index: 0;
 }
 
 .container > * {
-    position: relative;
-    z-index: 1;
+  position: relative;
+  z-index: 1;
 }
 
 .button {
-    padding: 10px 20px;
-    text-align: center;
-    text-decoration: none;
-    display: inline-block;
-    font-size: 16px;
-    margin: 4px 2px;
-    cursor: pointer;
-    width: 100%;
+  padding: 10px 20px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  margin: 4px 2px;
+  cursor: pointer;
+  width: 100%;
 }
 
 .stack {
-    width: 100%
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- ensure quick actions container fills the viewport
- make all MobileQuickActions containers fluid
- run prettier on UserQuickActionsDisplay

## Testing
- `npm run prettier:check`
- `npm run test` *(fails: `next` not found)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_684acb598eec8326b8d195f8c32da2a7