### PR TITLE
Fix avatar URLs for mobile

### DIFF
--- a/frontend/lib/resolveAvatarUrl.ts
+++ b/frontend/lib/resolveAvatarUrl.ts
@@ -1,23 +1,14 @@
-export function resolveAvatarUrl(avatarUrl?: string): string | undefined {
-  // Log the raw argument on every invocation:
-  console.log("[resolveAvatarUrl] received avatarUrl →", avatarUrl);
+import api from "../api/api";
 
+export function resolveAvatarUrl(avatarUrl?: string): string | undefined {
   if (!avatarUrl) {
-    console.log(
-      "[resolveAvatarUrl] avatarUrl is undefined or empty → returning undefined",
-    );
     return undefined;
   }
 
   try {
-    const fullUrl = new URL(avatarUrl, "http://localhost:8000").href;
-    console.log("[resolveAvatarUrl] built full URL →", fullUrl);
-    return fullUrl;
-  } catch (err) {
-    console.log(
-      "[resolveAvatarUrl] URL constructor threw, falling back to raw avatarUrl →",
-      avatarUrl,
-    );
+    const baseUrl = api.defaults.baseURL ?? "";
+    return new URL(avatarUrl, baseUrl).href;
+  } catch {
     return avatarUrl;
   }
 }


### PR DESCRIPTION
## Summary
- remove debug logging from `resolveAvatarUrl`
- build avatar URLs using `api` base to avoid localhost on mobile

## Testing
- `yarn install`
- `yarn test` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_b_684acb2a74b88326b589db5d6cce9a6c