### PR TITLE
Fix database session handling

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -16,8 +16,9 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
 
 def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+    """Yield a database session and ensure it is closed."""
+    with SessionLocal() as db:
+        try:
+            yield db
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary
- wrap database session usage with a context manager
- ensure the file ends with `db.close()` followed by a newline

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ad365bac883268f39361701e71101