### PR TITLE
Set default API URL

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,3 +36,8 @@ This template comes with the following features:
 - `storybook` – starts storybook dev server
 - `storybook:build` – build production storybook bundle to `storybook-static`
 - `prettier:write` – formats all files with Prettier
+
+## Environment variables
+
+Set `NEXT_PUBLIC_API_URL` in `.env.local` to specify the backend base URL. When
+not provided, it defaults to `http://localhost:8000`.

--- a/frontend/api/api.ts
+++ b/frontend/api/api.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://100.120.48.51:8000", // adjust if your FastAPI runs elsewhere
+  baseURL: process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000", // adjust if your FastAPI runs elsewhere
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- default API URL to `http://localhost:8000`
- document the `NEXT_PUBLIC_API_URL` variable

## Testing
- `npm test` *(fails: code style issues)*

------
https://chatgpt.com/codex/tasks/task_b_684ad362c66c832683c0dccae2d7b12e