### PR TITLE
Introduce database session context manager

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from contextlib import contextmanager
 import os
 
 DB_USER = os.getenv("POSTGRES_USER")
@@ -14,6 +15,16 @@ DATABASE_URL = (f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
+
+
+@contextmanager
+def session_scope(session_factory: sessionmaker = SessionLocal):
+    """Provide a transactional scope around a series of operations."""
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
 
 def get_db():
     db = SessionLocal()

--- a/backend/tests/test_avatar_deletion.py
+++ b/backend/tests/test_avatar_deletion.py
@@ -30,11 +30,8 @@ Base.metadata.create_all(bind=engine)
 
 
 def override_get_db():
-    db = TestingSessionLocal()
-    try:
+    with TestingSessionLocal() as db:
         yield db
-    finally:
-        db.close()
 
 client = TestClient(app)
 

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -46,11 +46,8 @@ def create_test_app():
     Base.metadata.create_all(bind=test_engine)
 
     def override_get_db():
-        db = TestingSessionLocal()
-        try:
+        with TestingSessionLocal() as db:
             yield db
-        finally:
-            db.close()
 
     app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)

--- a/backend/tests/test_longest_streaks.py
+++ b/backend/tests/test_longest_streaks.py
@@ -38,11 +38,8 @@ def create_test_app():
     Base.metadata.create_all(bind=test_engine)
 
     def override_get_db():
-        db = TestingSessionLocal()
-        try:
+        with TestingSessionLocal() as db:
             yield db
-        finally:
-            db.close()
 
     app.dependency_overrides[get_db] = override_get_db
     client = TestClient(app)

--- a/backend/tests/test_monthly_drinks.py
+++ b/backend/tests/test_monthly_drinks.py
@@ -29,33 +29,29 @@ Base.metadata.create_all(bind=engine)
 
 
 def override_get_db():
-    db = TestingSessionLocal()
-    try:
+    with TestingSessionLocal() as db:
         yield db
-    finally:
-        db.close()
 
 client = TestClient(app)
 
 
 def test_monthly_drinks():
     app.dependency_overrides[get_db] = override_get_db
-    db = TestingSessionLocal()
-    user = Person(name="Test")
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-    user_id = user.id
-    base = datetime.utcnow().replace(day=15, hour=0, minute=0, second=0, microsecond=0)
-    events = [
-        DrinkEvent(person_id=user.id, timestamp=base),
-        DrinkEvent(person_id=user.id, timestamp=_subtract_months(base, 1)),
-        DrinkEvent(person_id=user.id, timestamp=_subtract_months(base, 7)),
-    ]
-    db.add_all(events)
-    db.commit()
-    user_id = user.id
-    db.close()
+    with TestingSessionLocal() as db:
+        user = Person(name="Test")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        user_id = user.id
+        base = datetime.utcnow().replace(day=15, hour=0, minute=0, second=0, microsecond=0)
+        events = [
+            DrinkEvent(person_id=user.id, timestamp=base),
+            DrinkEvent(person_id=user.id, timestamp=_subtract_months(base, 1)),
+            DrinkEvent(person_id=user.id, timestamp=_subtract_months(base, 7)),
+        ]
+        db.add_all(events)
+        db.commit()
+        user_id = user.id
 
     resp = client.get(f"/users/{user_id}/monthly_drinks")
     assert resp.status_code == 200

--- a/backend/tests/test_social_sip.py
+++ b/backend/tests/test_social_sip.py
@@ -31,11 +31,8 @@ Base.metadata.create_all(bind=engine)
 
 
 def override_get_db():
-    db = TestingSessionLocal()
-    try:
+    with TestingSessionLocal() as db:
         yield db
-    finally:
-        db.close()
 
 
 client = TestClient(app)
@@ -43,28 +40,27 @@ client = TestClient(app)
 
 def test_social_sip_score():
     app.dependency_overrides[get_db] = override_get_db
-    db = TestingSessionLocal()
-    alice = Person(name="Alice")
-    bob = Person(name="Bob")
-    charlie = Person(name="Charlie")
-    db.add_all([alice, bob, charlie])
-    db.commit()
-    db.refresh(alice)
-    db.refresh(bob)
-    db.refresh(charlie)
-    alice_id = alice.id
-    bob_id = bob.id
+    with TestingSessionLocal() as db:
+        alice = Person(name="Alice")
+        bob = Person(name="Bob")
+        charlie = Person(name="Charlie")
+        db.add_all([alice, bob, charlie])
+        db.commit()
+        db.refresh(alice)
+        db.refresh(bob)
+        db.refresh(charlie)
+        alice_id = alice.id
+        bob_id = bob.id
 
-    base_time = datetime.utcnow()
-    events = [
-        DrinkEvent(person_id=alice.id, timestamp=base_time),
-        DrinkEvent(person_id=bob.id, timestamp=base_time + timedelta(minutes=1)),
-        DrinkEvent(person_id=alice.id, timestamp=base_time + timedelta(minutes=2)),
-        DrinkEvent(person_id=charlie.id, timestamp=base_time + timedelta(minutes=10)),
-    ]
-    db.add_all(events)
-    db.commit()
-    db.close()
+        base_time = datetime.utcnow()
+        events = [
+            DrinkEvent(person_id=alice.id, timestamp=base_time),
+            DrinkEvent(person_id=bob.id, timestamp=base_time + timedelta(minutes=1)),
+            DrinkEvent(person_id=alice.id, timestamp=base_time + timedelta(minutes=2)),
+            DrinkEvent(person_id=charlie.id, timestamp=base_time + timedelta(minutes=10)),
+        ]
+        db.add_all(events)
+        db.commit()
 
     resp = client.get(f"/users/{alice_id}/buddies")
     assert resp.status_code == 200

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -32,11 +32,8 @@ def client():
     app = FastAPI()
 
     def override_get_db():
-        db = TestingSessionLocal()
-        try:
+        with TestingSessionLocal() as db:
             yield db
-        finally:
-            db.close()
 
     app.dependency_overrides[get_db] = override_get_db
 


### PR DESCRIPTION
## Summary
- add `session_scope` helper in backend
- use context manager in test fixtures and setup logic

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `PYTHONPATH=backend pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_b_684ad356a7e08326868ea6d20c3b0e43