### PR TITLE
Add env setup fixture

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pytest
+from passlib.context import CryptContext
+
+
+def set_env_vars():
+    os.environ.setdefault("POSTGRES_USER", "test")
+    os.environ.setdefault("POSTGRES_PASSWORD", "test")
+    os.environ.setdefault("POSTGRES_DB", "test")
+    os.environ.setdefault("POSTGRES_HOST", "localhost")
+    os.environ.setdefault("POSTGRES_PORT", "5432")
+    os.environ.setdefault("TESTING", "1")
+    os.environ.setdefault("ADMIN_SECRET_KEY", "testsecret")
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+    if "ADMIN_PASSWORD_HASH" not in os.environ:
+        pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+        os.environ["ADMIN_PASSWORD_HASH"] = pwd_context.hash("admin")
+
+    return os.environ
+
+
+@pytest.fixture(scope="session")
+def env_vars():
+    return set_env_vars()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,18 +1,10 @@
-import os
+import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from jose import jwt
-from passlib.context import CryptContext
 
-os.environ["ADMIN_SECRET_KEY"] = "testsecret"
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
-
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-hashed = pwd_context.hash("admin")
-os.environ["ADMIN_PASSWORD_HASH"] = hashed
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from fastapi import FastAPI
 from app.auth import router

--- a/backend/tests/test_avatar_deletion.py
+++ b/backend/tests/test_avatar_deletion.py
@@ -1,5 +1,8 @@
 import os
 import sys
+import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -7,13 +10,7 @@ from sqlalchemy.pool import StaticPool
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-# Provide dummy env vars
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
-os.environ["TESTING"] = "1"
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from app.main import app, get_db
 from app.models import Base, Person

--- a/backend/tests/test_leaderboard.py
+++ b/backend/tests/test_leaderboard.py
@@ -1,4 +1,6 @@
 import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, and_
 from sqlalchemy.orm import sessionmaker
@@ -7,6 +9,8 @@ from datetime import timedelta
 import sys
 import types
 from unittest import mock
+
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 # Stub mollie client to avoid optional dependency in tests
 mollie = types.ModuleType("mollie")

--- a/backend/tests/test_longest_streaks.py
+++ b/backend/tests/test_longest_streaks.py
@@ -6,6 +6,10 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from unittest import mock
 import pytest
+import conftest
+conftest.set_env_vars()
+
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 # Stub mollie client to avoid optional dependency in tests
 mollie = types.ModuleType("mollie")

--- a/backend/tests/test_monthly_drinks.py
+++ b/backend/tests/test_monthly_drinks.py
@@ -1,19 +1,17 @@
+import os
+import sys
+import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from datetime import datetime
-import os
-import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
-os.environ["TESTING"] = "1"
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from app.main import app, get_db, _subtract_months
 from app.models import Base, Person, DrinkEvent

--- a/backend/tests/test_social_sip.py
+++ b/backend/tests/test_social_sip.py
@@ -1,21 +1,18 @@
+import os
+import sys
+import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from datetime import datetime, timedelta
-import os
-import sys
 
 # Ensure backend/app is in path
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-# Set env vars for database module
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
-os.environ["TESTING"] = "1"
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from app.main import app, get_db
 from app.models import Base, Person, DrinkEvent

--- a/backend/tests/test_user_stats.py
+++ b/backend/tests/test_user_stats.py
@@ -1,21 +1,18 @@
+import os
+import sys
+import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 from datetime import datetime, timedelta
-import sys
-import os
 
 # Ensure backend/app is in path
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-# Provide dummy env vars so database module can be imported
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
-os.environ["TESTING"] = "1"
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from app.main import app, get_db
 from app.models import Base, Person, DrinkEvent

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import pytest
+import conftest
+conftest.set_env_vars()
 from fastapi import FastAPI, Depends
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
@@ -9,11 +11,7 @@ from sqlalchemy.orm import sessionmaker
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-os.environ.setdefault("POSTGRES_USER", "test")
-os.environ.setdefault("POSTGRES_PASSWORD", "test")
-os.environ.setdefault("POSTGRES_DB", "test")
-os.environ.setdefault("POSTGRES_HOST", "localhost")
-os.environ.setdefault("POSTGRES_PORT", "5432")
+pytestmark = pytest.mark.usefixtures("env_vars")
 
 from app.database import Base, get_db
 from app import crud, schemas


### PR DESCRIPTION
## Summary
- add `set_env_vars` helper and `env_vars` fixture
- use helper in all backend tests

## Testing
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ad3645d1483268de503720f547eb4