### PR TITLE
Implement user comparison stats

### DIFF
--- a/backend/tests/test_monthly_totals.py
+++ b/backend/tests/test_monthly_totals.py
@@ -1,0 +1,65 @@
+import os, sys
+import pytest
+import conftest
+conftest.set_env_vars()
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from datetime import datetime
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+pytestmark = pytest.mark.usefixtures("env_vars")
+
+from app.main import app, get_db, _subtract_months
+from app.models import Base, Person, DrinkEvent
+
+engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    with TestingSessionLocal() as db:
+        yield db
+
+client = TestClient(app)
+
+
+def test_monthly_totals_multi():
+    app.dependency_overrides[get_db] = override_get_db
+    with TestingSessionLocal() as db:
+        alice = Person(name="Alice")
+        bob = Person(name="Bob")
+        db.add_all([alice, bob])
+        db.commit()
+        db.refresh(alice)
+        db.refresh(bob)
+        base = datetime.utcnow().replace(day=15, hour=0, minute=0, second=0, microsecond=0)
+        events = [
+            DrinkEvent(person_id=alice.id, timestamp=base),
+            DrinkEvent(person_id=bob.id, timestamp=base),
+            DrinkEvent(person_id=bob.id, timestamp=_subtract_months(base, 1)),
+        ]
+        db.add_all(events)
+        db.commit()
+        alice_id = alice.id
+        bob_id = bob.id
+
+    resp = client.get(f"/insights/monthly_totals", params={"user_ids": f"{alice_id},{bob_id}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    months = {row["month"] for row in data}
+    assert len(months) == 6
+    # counts
+    counts = {(row["userId"], row["month"]): row["count"] for row in data}
+    assert counts[(alice_id, base.strftime("%Y-%m"))] == 1
+    assert counts[(bob_id, base.strftime("%Y-%m"))] == 1
+    assert counts[(bob_id, _subtract_months(base, 1).strftime("%Y-%m"))] == 1
+    app.dependency_overrides.clear()

--- a/frontend/components/Stats/MonthlyDrinkVolumeChart.tsx
+++ b/frontend/components/Stats/MonthlyDrinkVolumeChart.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import type { MonthlyVolumeEntry } from "../../types/insights";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+interface Props {
+  data: MonthlyVolumeEntry[];
+  users: Record<number, string>;
+}
+
+const colors = [
+  "#1c7ed6",
+  "#37b24d",
+  "#f59f00",
+  "#e03131",
+  "#ae3ec9",
+  "#0ca678",
+];
+
+export default function MonthlyDrinkVolumeChart({ data, users }: Props) {
+  const months = Array.from(new Set(data.map((d) => d.month))).sort();
+  const datasets = Object.entries(users).map(([idStr, name], idx) => {
+    const id = parseInt(idStr, 10);
+    return {
+      label: name,
+      backgroundColor: colors[idx % colors.length],
+      data: months.map((m) => {
+        const row = data.find((d) => d.userId === id && d.month === m);
+        return row ? row.count : 0;
+      }),
+    };
+  });
+  const chartData = {
+    labels: months,
+    datasets,
+  };
+  return <Bar data={chartData} options={{ responsive: true }} />;
+}

--- a/frontend/components/Stats/UserMonthlyComparison.tsx
+++ b/frontend/components/Stats/UserMonthlyComparison.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState, useMemo } from "react";
+import { MultiSelect, Loader } from "@mantine/core";
+import api from "../../api/api";
+import type { Person } from "../../types";
+import type { MonthlyVolumeEntry } from "../../types/insights";
+import MonthlyDrinkVolumeChart from "./MonthlyDrinkVolumeChart";
+import classes from "../../styles/StatsPage.module.css";
+
+export default function UserMonthlyComparison() {
+  const [users, setUsers] = useState<Person[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [data, setData] = useState<MonthlyVolumeEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    api.get<Person[]>("/users").then((res) => setUsers(res.data));
+  }, []);
+
+  const options = users.map((u) => ({ value: u.id.toString(), label: u.name }));
+
+  const idToName = useMemo(() => {
+    const map: Record<number, string> = {};
+    users.forEach((u) => {
+      map[u.id] = u.name;
+    });
+    return map;
+  }, [users]);
+
+  useEffect(() => {
+    if (selected.length === 0) {
+      setData([]);
+      return;
+    }
+    setLoading(true);
+    api
+      .get<MonthlyVolumeEntry[]>("/insights/monthly_totals", {
+        params: { user_ids: selected.join(",") },
+      })
+      .then((res) => setData(res.data))
+      .finally(() => setLoading(false));
+  }, [selected]);
+
+  return (
+    <div className={classes.userInsightPanel}>
+      <MultiSelect
+        label="Select users"
+        placeholder="Choose users"
+        data={options}
+        searchable
+        value={selected}
+        onChange={setSelected}
+        clearable
+      />
+      {loading && <Loader />}
+      {!loading && selected.length > 0 && (
+        <MonthlyDrinkVolumeChart data={data} users={idToName} />
+      )}
+    </div>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,11 +27,13 @@
     "@next/bundle-analyzer": "^15.2.3",
     "@tabler/icons-react": "^3.31.0",
     "axios": "^1.8.4",
+    "chart.js": "^4.4.9",
     "date-fns": "^4.1.0",
     "js-cookie": "^3.0.5",
     "next": "15.2.3",
     "pg": "^8.16.0",
     "react": "19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "19.0.0",
     "recharts": "2.8.0"
   },

--- a/frontend/pages/StatsPage.tsx
+++ b/frontend/pages/StatsPage.tsx
@@ -1,19 +1,17 @@
 import React from "react";
-import { useState } from "react";
-import {
-  Container,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Container, Title, Paper } from "@mantine/core";
+import UserMonthlyComparison from "../components/Stats/UserMonthlyComparison";
 import classes from "../styles/StatsPage.module.css";
 
 function StatsPage() {
   return (
     <Container size="xl" py="md" className={classes.statsContainer}>
-      <Title>Statistics </Title>
-      <Text size="sm" color="dimmed" mb="md">
-        View insights about users, drinks, and more. coming soon.
-      </Text>
+      <Title order={1} mb="sm">
+        Statistics
+      </Title>
+      <Paper p="md" className={classes.userInsightSection}>
+        <UserMonthlyComparison />
+      </Paper>
     </Container>
   );
 }

--- a/frontend/pages/__tests__/StatsPage.test.tsx
+++ b/frontend/pages/__tests__/StatsPage.test.tsx
@@ -1,0 +1,28 @@
+import MockAdapter from "axios-mock-adapter";
+import api from "../../api/api";
+import { render, screen, userEvent, waitFor } from "../../test-utils";
+import StatsPage from "../StatsPage";
+
+const mock = new MockAdapter(api);
+
+afterEach(() => {
+  mock.reset();
+  mock.restore();
+});
+
+test("renders user monthly comparison chart", async () => {
+  mock.onGet("/users").reply(200, [
+    { id: 1, name: "Alice" },
+    { id: 2, name: "Bob" },
+  ]);
+  mock.onGet(/\/insights\/monthly_totals/).reply(200, [
+    { userId: 1, month: "2024-01", count: 2 },
+    { userId: 2, month: "2024-01", count: 1 },
+  ]);
+  render(<StatsPage />);
+  const combo = await screen.findByRole("combobox");
+  await userEvent.click(combo);
+  await userEvent.click(screen.getByText(/alice/i));
+  await waitFor(() => expect(mock.history.get.length).toBeGreaterThan(1));
+  expect(await screen.findByRole("img", { hidden: true })).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add new API endpoint for multi-user monthly drink totals
- support monthly comparison chart on stats page
- create new React chart components
- add backend & frontend tests
- install chart.js

## Testing
- `npm test --silent` *(fails: ESLint errors)*
- `pytest -q` *(fails: ModuleNotFoundError: passlib)*

------
https://chatgpt.com/codex/tasks/task_b_684ad5ae9b4883268ff34a7a8830023f