### PR TITLE
Add in-app midnight backup scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,16 +99,9 @@ Usage example:
 ./scripts/backup_db.sh gdrive DrinkTrackerBackups
 ```
 
-To run the backup every day at 2 AM via cron:
-
-```cron
-0 2 * * * /path/to/DrinkTracker/scripts/backup_db.sh gdrive DrinkTrackerBackups
-```
-
-You can automate the setup using `scripts/install_backup_cron.sh`, which creates a daily cron entry. The following command installs a job that runs at 2 AM every day:
-
-```bash
-./scripts/install_backup_cron.sh gdrive DrinkTrackerBackups 2
-```
+The backend automatically runs this backup every day at midnight while the
+application is running. Set `BACKUP_REMOTE_NAME` and `BACKUP_REMOTE_PATH` in the
+environment to customize the destination. Use `DISABLE_BACKUPS=1` if you wish to
+disable this scheduler.
 
 <p align="right">(<a href="#top">Back to top</a>)</p>

--- a/backend/app/backup_scheduler.py
+++ b/backend/app/backup_scheduler.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+from pathlib import Path
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+scheduler = AsyncIOScheduler()
+
+
+def run_backup() -> None:
+    """Run the backup script with configured settings."""
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "backup_db.sh"
+    remote = os.getenv("BACKUP_REMOTE_NAME", "gdrive")
+    remote_path = os.getenv("BACKUP_REMOTE_PATH", "DrinkTrackerBackups")
+    subprocess.run([str(script_path), remote, remote_path], check=True)
+
+
+def start_backup_scheduler() -> None:
+    """Start a daily backup job at midnight unless disabled."""
+    if os.getenv("DISABLE_BACKUPS") == "1":
+        return
+    scheduler.add_job(run_backup, "cron", hour=0, minute=0)
+    scheduler.start()
+
+
+def shutdown_backup_scheduler() -> None:
+    """Shutdown the scheduler if running."""
+    if scheduler.running:
+        scheduler.shutdown()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
+from .backup_scheduler import start_backup_scheduler, shutdown_backup_scheduler
+
 from .database import engine, Base, get_db
 from .auth import router as auth_router
 from .routers import users, payments, stats
@@ -51,3 +53,13 @@ __all__ = [
     "longest_hydration_streaks",
     "_subtract_months",
 ]
+
+
+@app.on_event("startup")
+async def _start_scheduler() -> None:
+    start_backup_scheduler()
+
+
+@app.on_event("shutdown")
+async def _stop_scheduler() -> None:
+    shutdown_backup_scheduler()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ python-jose
 passlib[bcrypt]
 pytest
 python-multipart
+apscheduler

--- a/backend/tests/test_backup_scheduler.py
+++ b/backend/tests/test_backup_scheduler.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import app.backup_scheduler as bs
+
+pytestmark = pytest.mark.usefixtures("env_vars")
+
+
+def test_run_backup_invokes_script(env_vars):
+    with mock.patch.object(bs.subprocess, "run") as run:
+        bs.run_backup()
+        script = Path(__file__).resolve().parents[2] / "scripts" / "backup_db.sh"
+        run.assert_called_once_with([str(script), "gdrive", "DrinkTrackerBackups"], check=True)
+
+
+def test_start_backup_scheduler_adds_job(env_vars):
+    with mock.patch.object(bs, "scheduler") as sched:
+        os.environ.pop("DISABLE_BACKUPS", None)
+        bs.start_backup_scheduler()
+        sched.add_job.assert_called()
+        sched.start.assert_called_once()
+

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+# Ensure required commands are available
+command -v pg_dump >/dev/null 2>&1 || { echo "pg_dump is required but not installed." >&2; exit 1; }
+command -v rclone >/dev/null 2>&1 || { echo "rclone is required but not installed." >&2; exit 1; }
+
 # Usage: ./backup_db.sh [remote_name] [remote_path]
 # remote_name: rclone remote name (e.g., gdrive or onedrive)
 # remote_path: directory path on the remote (default: DrinkTrackerBackups)

--- a/scripts/install_backup_cron.sh
+++ b/scripts/install_backup_cron.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 REMOTE_NAME="${1:-gdrive}"
 REMOTE_PATH="${2:-DrinkTrackerBackups}"
-HOUR="${3:-2}"
+HOUR="${3:-0}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRON_ENTRY="0 ${HOUR} * * * ${SCRIPT_DIR}/backup_db.sh ${REMOTE_NAME} ${REMOTE_PATH} >/dev/null 2>&1"


### PR DESCRIPTION
## Summary
- run automatic database backups from FastAPI app
- expose environment variables to configure backup destination
- document the new scheduler behaviour
- test backup scheduler helpers

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684ae35f621c83269cb418f979a92d36