### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -125,9 +125,12 @@ async def upload_avatar(
         if os.path.exists(old_path):
             os.remove(old_path)
 
-    ext = os.path.splitext(file.filename)[1]
+    from werkzeug.utils import secure_filename
+    ext = os.path.splitext(secure_filename(file.filename))[1]
     filename = f"{user_id}_{uuid4().hex}{ext}"
-    filepath = os.path.join(avatars_dir, filename)
+    filepath = os.path.normpath(os.path.join(avatars_dir, filename))
+    if not filepath.startswith(avatars_dir):
+        raise HTTPException(status_code=400, detail="Invalid file path")
     with open(filepath, "wb") as buffer:
         buffer.write(await file.read())
     avatar_url = f"/avatars/{filename}"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ python-jose
 passlib[bcrypt]
 pytest
 python-multipart
+werkzeug==3.1.3


### PR DESCRIPTION
Potential fix for [https://github.com/Pecako2001/DrinkTracker/security/code-scanning/2](https://github.com/Pecako2001/DrinkTracker/security/code-scanning/2)

To fix the issue, we need to ensure that the constructed file path is safe and contained within the intended directory (`avatars_dir`). This can be achieved by normalizing the path using `os.path.normpath` and verifying that the resulting path starts with the `avatars_dir` prefix. Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the `file.filename` to eliminate special characters and ensure safe file naming.

Changes required:
1. Normalize the constructed `filepath` using `os.path.normpath`.
2. Validate that the normalized path starts with `avatars_dir`.
3. Use `secure_filename` to sanitize `file.filename`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
